### PR TITLE
chore: remove sollegacy market

### DIFF
--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -49,7 +49,6 @@ export const mainnetSlugs = [
   'hdro-inj',
   'nonja-inj',
   'lvn-inj',
-  'sollegacy-usdt',
   'w-usdt',
   'bonus-usdt',
   'xiii-inj',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed obsolete `sollegacy-usdt` entry from the list of supported markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->