### PR TITLE
chore: add gbp and eur perp

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,6 @@
 export const newMarkets = [
+  'gbp-usdt-perp',
+  'eur-usdt-perp',
   'xau-usdt-perp',
   'xag-usdt-perp',
   'ezeth-weth',
@@ -9,8 +11,6 @@ export const newMarkets = [
   'omni-usdt-perp',
   'xiii-inj',
   'w-usdt',
-  'bonus-usdt',
-  'ena-usdt',
 ]
 
 export const experimental = [

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -28,6 +28,8 @@ export const mainnetSlugs: string[] = [
   'w-usdt-perp',
   'xau-usdt-perp',
   'xag-usdt-perp',
+  'gbp-usdt-perp',
+  'eur-usdt-perp',
 ]
 
 export const devnetSlugs: string[] = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for new markets: `GBP/USDT perpetual` and `EUR/USDT perpetual`.

- **Updates**
  - Removed support for `BONUS/USDT` and `ENA/USDT` markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->