### PR TITLE
#PR48

### DIFF
--- a/tokens/mainnet.json
+++ b/tokens/mainnet.json
@@ -3314,6 +3314,19 @@
     "externalLogo": "boden.png"
   },
   {
+    "address": "bonk",
+    "isNative": false,
+    "tokenVerification": "internal",
+    "decimals": 5,
+    "name": "BONK",
+    "symbol": "BONK",
+    "logo": "https://imagedelivery.net/DYKOWp0iCc0sIkF-2e4dNw/e54b2aea-b373-4ce3-e598-14417d363e00/public",
+    "coinGeckoId": "bonk",
+    "tokenType": "symbol",
+    "denom": "bonk",
+    "externalLogo": "bonk.jpeg"
+  },
+  {
     "address": "btc",
     "isNative": false,
     "tokenVerification": "internal",

--- a/tokens/staticTokens/mainnet.json
+++ b/tokens/staticTokens/mainnet.json
@@ -24,6 +24,18 @@
     "denom": "boden"
   },
   {
+    "address": "bonk",
+    "isNative": false,
+    "tokenVerification": "internal",
+    "decimals": 5,
+    "name": "BONK",
+    "symbol": "BONK",
+    "logo": "bonk.jpeg",
+    "coinGeckoId": "bonk",
+    "tokenType": "symbol",
+    "denom": "bonk"
+  },
+  {
     "address": "btc",
     "isNative": false,
     "tokenVerification": "internal",

--- a/ts-scripts/data/untaggedSymbolMeta.ts
+++ b/ts-scripts/data/untaggedSymbolMeta.ts
@@ -190,4 +190,12 @@ export const untaggedSymbolMeta = {
     coinGeckoId: 'jeo-boden',
     logo: 'boden.png'
   },
+
+  BONK: {
+    decimals: 5,
+    name: 'BONK',
+    symbol: 'BONK',
+    logo: 'bonk.jpeg',
+    coinGeckoId: 'bonk'
+  },
 }


### PR DESCRIPTION
## Situation
- I noticed BONK/USDT PERP market's token image is missing: 
<img width="242" alt="Screenshot 2024-06-06 at 8 20 54 AM" src="https://github.com/InjectiveLabs/injective-lists/assets/41407272/2be97097-2db3-4639-866b-05a8083ac647">

Issue is that BONK is not found on the `untaggedSymbolMeta` list, so the market's token meta for BONK is pulled from first possible match of a token with symbol "BONK" on mainnet.json

Fix is to add BONK to `untaggedSymbolMeta` list so can make it canonical the canonical meta for the perp market

Tested by copying over generated `mainnet.json` to helix, and image displayed