### PR TITLE
chore: modify giga meta

### DIFF
--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -1940,7 +1940,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
     logo: 'giga.png',
     name: 'Gigachad',
     symbol: 'GIGA',
-    decimals: 8
+    decimals: 5
   }
 
 }


### PR DESCRIPTION
reduced decimals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the decimal precision for the `Gigachad` token symbol from 8 to 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->