### PR TITLE
Chore/add giga market categories

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'giga-inj',
   'iotx-inj',
   'sns-inj',
   'pyusd-usdt',
@@ -9,8 +10,7 @@ export const newMarkets = [
   'xau-usdt-perp',
   'xag-usdt-perp',
   'ezeth-weth',
-  'saga-usdt',
-  'black-inj',
+  'saga-usdt'
 ]
 
 export const experimental = [
@@ -138,7 +138,9 @@ export const solana = [
   'w-usdt',
   'w-usdt-perp',
   'boden-usdt-perp',
-  'sns-inj'
+  'sns-inj',
+  'giga-inj'
+
 ]
 
 export const olpLowVolume = [

--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -60,7 +60,8 @@ export const mainnetSlugs = [
   'gme-inj',
   'pyusd-usdt',
   'sns-inj',
-  'iotx-inj'
+  'iotx-inj',
+  'giga-inj'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
added categories experimental and solanaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated market data to include support for `giga-inj`.
  - Removed `black-inj` from the market data.
  - Enhanced the `solana` market data with `giga-inj` inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->