### PR TITLE
chore: add usdy ibc token meta

### DIFF
--- a/ts-scripts/data/ibc.ts
+++ b/ts-scripts/data/ibc.ts
@@ -508,4 +508,14 @@ export const mainnetTokens: IbcTokenSource[] = [
     source: TokenSource.Solana,
     hash: '36C811A2253AA64B58A9B66C537B89348FE5792A8808AAA343082CBFCAA72278'
   }
+  ,
+  {
+    ...symbolMeta.USDY,
+    baseDenom: 'usdy',
+    isNative: true,
+    channelId: 'channel-148',
+    source: TokenSource.Cosmos,
+    path: 'transfer/channel-148',
+    hash: '93EAE5F9D6C14BFAC8DD1AFDBE95501055A7B22C5D8FA8C986C31D6EFADCA8A9'
+  }
 ]

--- a/ts-scripts/data/ibc.ts
+++ b/ts-scripts/data/ibc.ts
@@ -507,11 +507,10 @@ export const mainnetTokens: IbcTokenSource[] = [
     path: 'transfer/channel-183',
     source: TokenSource.Solana,
     hash: '36C811A2253AA64B58A9B66C537B89348FE5792A8808AAA343082CBFCAA72278'
-  }
-  ,
+  },
   {
     ...symbolMeta.USDY,
-    baseDenom: 'usdy',
+    baseDenom: 'ausdy',
     isNative: true,
     channelId: 'channel-148',
     source: TokenSource.Cosmos,


### PR DESCRIPTION
added ibc-specific USDY token metadata (left some of the USDY metadata as is because we'll still support USDY from ethereum)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the `USDY` token sourced from Cosmos to the mainnet tokens array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->