### PR TITLE
chore: update inj testnet address - skip deploy

### DIFF
--- a/ts-scripts/data/erc20.ts
+++ b/ts-scripts/data/erc20.ts
@@ -10,7 +10,7 @@ export const devnetTokens = [
 export const testnetTokens = [
   {
     ...symbolMeta.INJ,
-    address: '0xA472990C4C1261FEb55cDce66c53AbF990E83166'
+    address: '0x5512c04B6FF813f3571bDF64A1d74c98B5257332'
   },
   {
     ...symbolMeta.APE,


### PR DESCRIPTION
supports testing of peggy for chain upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the token address for INJ in the testnet. This ensures correct transactions and interactions for users on the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->