### PR TITLE
chore: modify erc20 usdy token metadata

### DIFF
--- a/ts-scripts/data/erc20.ts
+++ b/ts-scripts/data/erc20.ts
@@ -259,7 +259,7 @@ export const mainnetTokens = [
     address: '0x4c11249814f11b9346808179Cf06e71ac328c1b5'
   },
   {
-    ...symbolMeta.USDY,
+    ...symbolMeta.USDYet,
     address: '0x96F6eF951840721AdBF46Ac996b59E0235CB985C'
   },
   {

--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -849,7 +849,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
 
   USDYet: {
     decimals: 18,
-    symbol: 'USDY',
+    symbol: 'USDYet',
     logo: 'usdy.webp',
     name: 'Ondo US Dollar Yield',
     coinGeckoId: 'ondo-us-dollar-yield'

--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -847,7 +847,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
     coinGeckoId: 'kira-the-injective-cat'
   },
 
-  USDY: {
+  USDYet: {
     decimals: 18,
     symbol: 'USDY',
     logo: 'usdy.webp',
@@ -1973,6 +1973,14 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
     name: 'TEvmos',
     symbol: 'TEvmos',
     decimals: 18
+  },
+
+  USDY: {
+    decimals: 18,
+    symbol: 'USDY',
+    logo: 'usdy.webp',
+    name: 'Ondo US Dollar Yield',
+    coinGeckoId: 'ondo-us-dollar-yield'
   }
 
 }


### PR DESCRIPTION
trying to rename usdy from eth to usdyet - take a look pls ser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the `USDY` token to `USDYet` with enhanced details including the name "Ondo US Dollar Yield" and a `coinGeckoId`.
  - Added support for a new token `TEvmos`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->