### PR TITLE
chore: update mother token meta

### DIFF
--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -1849,7 +1849,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
 
   MOTHER: {
     decimals: 6,
-    name: 'MOTHER IZZY',
+    name: 'MOTHER IGGY',
     symbol: 'MOTHER',
     coinGeckoId: 'mother-iggy',
     logo: 'mother.webp'


### PR DESCRIPTION
minor update to mother token metadata (mother "iggy" not mother "izzy")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the displayed name of the symbol `MOTHER` from 'MOTHER IZZY' to 'MOTHER IGGY'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->