### PR TITLE
chore: add new usdy/usdt pair to fe, update categories

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'usdy-usdt',
   'giga-inj',
   'iotx-inj',
   'sns-inj',
@@ -62,11 +63,11 @@ export const cosmos = [
   'andr-usdt',
   'whale-inj',
   'saga-usdt',
-  'atom-usdt'
+  'atom-usdt',
+  'usdy-usdt'
 ]
 
 export const ethereum = [
-  'usdy-usdt',
   'inj-usdt',
   'arb-usdt',
   'app-inj',
@@ -126,7 +127,8 @@ export const injective = [
   'black-inj',
   'mother-inj',
   'sns-inj',
-  'iotx-inj'
+  'iotx-inj',
+  'usdy-usdt'
 ]
 
 export const solana = [


### PR DESCRIPTION
please someone merge before 7a eastern monday (so, morning time cet is good)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the trading pair `'usdy-usdt'` to the `newMarkets` and `cosmos` categories.
	- Enhanced relevance of the `'usdy-usdt'` trading pair within the `injective` category.
	- Removed `'usdy-usdt'` from the `ethereum` category, reflecting updated market focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->