### PR TITLE
chore: add btc-wusdm perp and wusdm-usdt to fe

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,10 +1,11 @@
 export const newMarkets = [
+  'btc-wusdm-perp',
+  'wusdm-usdt',
   'usdy-usdt',
   'giga-inj',
   'iotx-inj',
   'sns-inj',
   'pyusd-usdt',
-  'boden-usdt-perp',
   'mother-inj',
   'gbp-usdt-perp',
   'eur-usdt-perp',
@@ -15,6 +16,8 @@ export const newMarkets = [
 ]
 
 export const experimental = [
+  'btc-wusdm-perp',
+  'wusdm-usdt',
   'usdy-usdt',
   'ape-usdt',
   'usde-usdt',
@@ -68,6 +71,7 @@ export const cosmos = [
 ]
 
 export const ethereum = [
+  'wusdm-usdt',
   'inj-usdt',
   'arb-usdt',
   'app-inj',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -30,7 +30,7 @@ export const mainnetSlugs: string[] = [
   'xag-usdt-perp',
   'gbp-usdt-perp',
   'eur-usdt-perp',
-  'boden-usdt-perp'
+  'btc-wusdm-perp'
 ]
 
 export const devnetSlugs: string[] = []

--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -1849,7 +1849,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
 
   MOTHER: {
     decimals: 6,
-    name: 'MOTHER IZZY',
+    name: 'MOTHER IGGY',
     symbol: 'MOTHER',
     coinGeckoId: 'mother-iggy',
     logo: 'mother.webp'


### PR DESCRIPTION
add btc-wusdm perp and wusdm-usdt to fe, add correct market categories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added two new trading pairs: `'btc-wusdm-perp'` and `'wusdm-usdt'` to the market offerings.
	- Updated the Ethereum market to include the `'wusdm-usdt'` pair.

- **Bug Fixes**
	- Removed the obsolete trading pair `'boden-usdt-perp'` from the new markets.
	- Replaced `'boden-usdt-perp'` with `'btc-wusdm-perp'` in the mainnet trading pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->