### PR TITLE
chore: add ton-usdt to fe and remove some various categories

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'ton-usdt',
   'btc-wusdm-perp',
   'wusdm-usdt',
   'usdy-usdt',
@@ -16,35 +17,19 @@ export const newMarkets = [
 ]
 
 export const experimental = [
+  'ton-usdt',
   'btc-wusdm-perp',
   'wusdm-usdt',
   'usdy-usdt',
-  'ape-usdt',
   'usde-usdt',
   'app-inj',
-  'gf-usdt',
-  'autism-inj',
-  'tia-usdt-30nov2023',
-  '1000pepe-usdt-perp',
-  'eth-usdt-19sep22',
-  'ethbtctrend-usdt',
-  'steadyeth-usdt',
-  'steadybtc-usdt',
-  'app-inj',
-  'ninja-inj',
-  'kira-inj',
-  'katana-inj',
-  'ginger-inj',
   'jup-usdt-perp',
   'gyen-usdt',
   'wif-usdt-perp',
-  'bonk-usdt-perp',
   'qunt-inj',
-  'talis-inj',
   'omni-usdt-perp',
   'w-usdt-perp',
-  'mother-inj',
-  'boden-usdt-perp'
+  'mother-inj'
 ]
 
 export const cosmos = [
@@ -59,7 +44,6 @@ export const cosmos = [
   'atom-usdt-perp',
   'sei-usdt-perp',
   'axl-usdt-perp',
-  'tia-usdt-30nov2023',
   'tia-usdt-perp',
   'talis-usdt',
   'osmo-usdt-perp',
@@ -71,6 +55,7 @@ export const cosmos = [
 ]
 
 export const ethereum = [
+  'ton-usdt',
   'wusdm-usdt',
   'inj-usdt',
   'arb-usdt',
@@ -81,30 +66,22 @@ export const ethereum = [
   'link-usdt',
   'stinj-inj',
   'weth-usdt',
-  'evmos-usdt',
-  'gf-usdt',
   'wmatic-usdt',
-  'ethbtctrend-usdt',
   'steadyeth-usdt',
   'steadybtc-usdt',
   'inj-usdt-perp',
   'bonk-usdt-perp',
   'eth-usdt-perp',
   'bnb-usdt-perp',
-  'stx-usdt-perp',
   'eth-usdtkv-perp',
   'arb-usdt-perp',
-  'gyen-usdt',
   'op-usdt-perp',
   'link-usdt-perp',
   'ena-usdt',
   'w-usdt',
-  'bonus-usdt',
   'w-usdt-perp',
   'omni-usdt',
-  'ezeth-weth',
-  'pyusd-usdt',
-  'iotx-inj'
+  'pyusd-usdt'
 ]
 
 export const injective = [
@@ -125,9 +102,7 @@ export const injective = [
   'talis-inj',
   'hdro-inj',
   'pyth-inj',
-  'nonja-inj',
   'lvn-inj',
-  'xiii-inj',
   'black-inj',
   'mother-inj',
   'sns-inj',
@@ -147,7 +122,6 @@ export const solana = [
   'boden-usdt-perp',
   'sns-inj',
   'giga-inj'
-
 ]
 
 export const olpLowVolume = [
@@ -159,7 +133,6 @@ export const olpLowVolume = [
   'weth-usdt',
   'usdt-usdcet',
   'wmatic-usdt',
-  '1000pepe-usdt-perp',
   'atom-usdt-perp',
   'btc-usdt-perp',
   'eth-usdt-perp',
@@ -170,7 +143,6 @@ export const olpLowVolume = [
   'axl-usdt-perp',
   'kava-usdt',
   'sei-usdt-perp',
-  'tia-usdt-30nov2023',
   'tia-usdt-perp'
 ]
 

--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -36,7 +36,8 @@ export const mainnetSlugs = [
   'saga-usdt',
   'mother-inj',
   'asg-inj',
-  'wusdm-usdt'
+  'wusdm-usdt',
+  'ton-usdt'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
adding ton/usdt to verified, added categories, and in the process removed categories for some "delisted" tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the market entry `'ton-usdt'` to the new markets, experimental, and Ethereum categories.
	- Expanded the recognized slugs for the mainnet to include `'ton-usdt'`.

- **Bug Fixes**
	- Removed outdated or less relevant entries from the experimental, Ethereum, and low volume market categories to improve data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->