### PR TITLE
chore: add xiii-inj back to verified list

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -29,7 +29,8 @@ export const experimental = [
   'qunt-inj',
   'omni-usdt-perp',
   'w-usdt-perp',
-  'mother-inj'
+  'mother-inj',
+  'xiii-inj'
 ]
 
 export const cosmos = [
@@ -107,7 +108,8 @@ export const injective = [
   'mother-inj',
   'sns-inj',
   'iotx-inj',
-  'usdy-usdt'
+  'usdy-usdt',
+  'xiii-inj'
 ]
 
 export const solana = [

--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -37,7 +37,8 @@ export const mainnetSlugs = [
   'mother-inj',
   'asg-inj',
   'wusdm-usdt',
-  'ton-usdt'
+  'ton-usdt',
+  'xiii-inj'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
adding xiii-inj back to verified list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded market category identifiers by adding `'xiii-inj'` to the `experimental` and `injective` arrays.
	- Added `'xiii-inj'` to the `mainnetSlugs` array, enhancing data availability for market processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->