### PR TITLE
chore: remove buidl from rwa

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -155,6 +155,5 @@ export const rwa = [
   'xau-usdt-perp',
   'xag-usdt-perp',
   'eur-usdt-perp',
-  'gbp-usdt-perp',
-  'buidl-usdt-perp'
+  'gbp-usdt-perp'
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated market categories by removing the `'buidl-usdt-perp'` option, streamlining available choices for users.
  
- **Bug Fixes**
	- Corrected the market category list to ensure it reflects current offerings accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->