### PR TITLE
chore: buidl market

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,5 +1,5 @@
 export const newMarkets = [
-  // 'buidl-usdt-perp',
+  'buidl-usdt-perp',
   'ton-usdt',
   'btc-wusdm-perp',
   'wusdm-usdt',
@@ -18,7 +18,7 @@ export const newMarkets = [
 ]
 
 export const experimental = [
-  // 'buidl-usdt-perp',
+  'buidl-usdt-perp',
   'ton-usdt',
   'btc-wusdm-perp',
   'wusdm-usdt',
@@ -58,7 +58,7 @@ export const cosmos = [
 ]
 
 export const ethereum = [
-  // 'buidl-usdt-perp',
+  'buidl-usdt-perp',
   'ton-usdt',
   'wusdm-usdt',
   'inj-usdt',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -30,8 +30,8 @@ export const mainnetSlugs: string[] = [
   'xag-usdt-perp',
   'gbp-usdt-perp',
   'eur-usdt-perp',
-  'btc-wusdm-perp'
-  // 'buidl-usdt-perp'
+  'btc-wusdm-perp',
+  'buidl-usdt-perp'
 ]
 
 export const devnetSlugs: string[] = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `'buidl-usdt-perp'` as a valid market option in the new markets, experimental, and Ethereum categories.
	- Expanded the list of available trading pairs by including `'buidl-usdt-perp'` in the mainnet context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->