### PR TITLE
chore: add aave usdt perp to verified

### DIFF
--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -1,4 +1,5 @@
 export const mainnetSlugs: string[] = [
+  'aave-usdt-perp',
   'btc-usdt-perp',
   'inj-usdt-perp',
   'xrp-usdt-perp',


### PR DESCRIPTION
adding aaveusdt perp to verified on helix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for the 'Aave USDT Perpetual' trading pair, expanding available cryptocurrency derivatives for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->