### PR TITLE
chore: add crv to fe

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'crv-usdt-perp',
   'mkr-usdt-perp',
   'aave-usdt-perp',
   'buidl-usdt-perp',
@@ -60,6 +61,9 @@ export const cosmos = [
 ]
 
 export const ethereum = [
+  'crv-usdt-perp',
+  'mkr-usdt-perp',
+  'aave-usdt-perp',
   'buidl-usdt-perp',
   'ton-usdt',
   'wusdm-usdt',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -1,4 +1,5 @@
 export const mainnetSlugs: string[] = [
+  'crv-usdt-perp',
   'mkr-usdt-perp',
   'aave-usdt-perp',
   'btc-usdt-perp',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded market offerings with the addition of new trading pairs: 
		- `'crv-usdt-perp'` in the new markets list.
		- `'crv-usdt-perp'`, `'mkr-usdt-perp'`, and `'aave-usdt-perp'` in the Ethereum markets.
		- Added `'crv-usdt-perp'` to the mainnet derivatives list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->