### PR TITLE
chore: add tao perp to fe

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'tao-usdt-perp',
   'popcat-usdt-perp',
   'pepe-usdt-perp',
   'crv-usdt-perp',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -1,4 +1,5 @@
 export const mainnetSlugs: string[] = [
+  'tao-usdt-perp',
   'popcat-usdt-perp',
   'pepe-usdt-perp',
   'crv-usdt-perp',


### PR DESCRIPTION
add tao/usdt perp to fe (derivative), and new markets category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new trading market: 'tao-usdt-perp'.
	- Expanded the available market derivatives with the addition of 'tao-usdt-perp'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->