### PR TITLE
chore: whitelist 2024 election perp

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  '2024election-perp',
   'tao-usdt-perp',
   'popcat-usdt-perp',
   'pepe-usdt-perp',
@@ -24,6 +25,7 @@ export const newMarkets = [
 ]
 
 export const experimental = [
+  '2024election-perp',
   'buidl-usdt-perp',
   'ton-usdt',
   'btc-wusdm-perp',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -37,7 +37,8 @@ export const mainnetSlugs: string[] = [
   'gbp-usdt-perp',
   'eur-usdt-perp',
   'btc-wusdm-perp',
-  'buidl-usdt-perp'
+  'buidl-usdt-perp',
+  '2024election-perp'
 ]
 
 export const devnetSlugs: string[] = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the market entry `'2024election-perp'` to the `newMarkets` and `experimental` categories.
	- Added `'2024election-perp'` to the `mainnetSlugs` array, expanding the available market options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->