### PR TITLE
chore: add apt perp to verified

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'apt-usdt-perp',
   'ton-usdt-perp',
   'ftm-usdt-perp',
   '2024election-perp',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -1,4 +1,5 @@
 export const mainnetSlugs: string[] = [
+  'apt-usdt-perp',
   'ton-usdt-perp',
   'ftm-usdt-perp',
   'tao-usdt-perp',


### PR DESCRIPTION
add apt perp to verified, and new markets category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the new market pair `'apt-usdt-perp'`, expanding trading options for users.
	- Updated the list of available market slugs to include `'apt-usdt-perp'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->