### PR TITLE
chore: kava usdt grid

### DIFF
--- a/ts-scripts/data/grid/spot.ts
+++ b/ts-scripts/data/grid/spot.ts
@@ -142,6 +142,10 @@ export const mainnetGridMarkets = [
   {
     slug: 'pyusd-usdt',
     contractAddress: 'inj1qjp5una7prxzuzxy8ltwg965rr3plpl4sew009'
+  },
+  {
+    slug: 'kava-usdt',
+    contractAddress: 'inj1xqaauqjzg6zgdxxd0jcvtvj3xmg3q65njzpk77'
   }
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new market entries for 'kava-usdt' and 'pyth-usdt' on mainnet and staging environments.
	- Updated testnet markets to include 'inj-usdt', 'atom-usdt', and 'tia-usdt'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->