### PR TITLE
chore: add mother perp to fe

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'mother-usdt-perp',
   'apt-usdt-perp',
   'ton-usdt-perp',
   'ftm-usdt-perp',
@@ -132,6 +133,7 @@ export const injective = [
 ]
 
 export const solana = [
+  'mother-usdt-perp',
   'popcat-usdt-perp',
   'jup-usdt-perp',
   'pyth-usdt-perp',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -1,4 +1,5 @@
 export const mainnetSlugs: string[] = [
+  'mother-usdt-perp',
   'apt-usdt-perp',
   'ton-usdt-perp',
   'ftm-usdt-perp',


### PR DESCRIPTION
adding mother perp to verified pairs, also to categories new markets and solana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new trading market: 'mother-usdt-perp' for enhanced trading and analysis options.
	- Expanded the list of available slugs for the mainnet to include 'mother-usdt-perp'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->