### PR TITLE
adjust drugs token

### DIFF
--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -2040,7 +2040,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
   },
 
   DRUGS: {
-    decimals: 9,
+    decimals: 6,
     symbol: 'DRUGS',
     name: 'DRUGS',
     logo: 'drugs.png',

--- a/ts-scripts/data/tokenFactory.ts
+++ b/ts-scripts/data/tokenFactory.ts
@@ -441,6 +441,6 @@ export const mainnetTokens: TokenFactorySource[] = [
   },
   {
     ...symbolMeta.DRUGS,
-    creator: 'inj1sklcy2px26jj73ffs2f7fmxw77zsts66prrqxr'
+    creator: 'inj178zy7myyxewek7ka7v9hru8ycpvfnen6xeps89'
   }
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the decimal precision for the `DRUGS` token from 9 to 6, enhancing the accuracy of calculations and displays.
	- Changed the creator address for the `DRUGS` token, ensuring the correct attribution of token creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->