### PR TITLE
fix: support upper and lowercase addys in ofac file

### DIFF
--- a/ts-scripts/generateOfacList.ts
+++ b/ts-scripts/generateOfacList.ts
@@ -5,7 +5,8 @@ async function generateOFACList() {
   const response = await new HttpClient(
     'https://www.treasury.gov/ofac/downloads/sanctions/1.0/'
   ).get<{}, { data: string }>('sdn_advanced.xml')
-  const result = response.data.match(/(\b0x[a-f0-9]{40}\b)/g)
+  const rawResults = response.data.match(/(\b0x[a-fA-F0-9]{40}\b)/g)
+  const result = rawResults ? [... new Set(rawResults.map(address => address.toLowerCase()))] : [];
 
   if (!result) {
     return


### PR DESCRIPTION
This accounts for lower and upper casing in the downloaded list. Additionally this converts the final results to lowercase and removes the dupes.