### PR TITLE
chore: add wusdl spot to fe

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'wusdl-usdt'
   'mother-usdt-perp',
   'apt-usdt-perp',
   'ton-usdt-perp',
@@ -29,6 +30,7 @@ export const newMarkets = [
 ]
 
 export const experimental = [
+  'wusdl-usdt'
   '2024election-perp',
   'buidl-usdt-perp',
   'ton-usdt',
@@ -70,6 +72,7 @@ export const cosmos = [
 ]
 
 export const ethereum = [
+  'wusdl-usdt'
   'ton-usdt-perp',
   'pepe-usdt-perp',
   'crv-usdt-perp',

--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -39,7 +39,8 @@ export const mainnetSlugs = [
   'wusdm-usdt',
   'ton-usdt',
   'xiii-inj',
-  'hdro-usdt'
+  'hdro-usdt',
+  'wusdl-usdt'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
add wusdl/usdt spot to fe 

> [!CAUTION]
> please do not merge until **16 oct** AM 9am or 10am GMT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the market identifier `'wusdl-usdt'` to the `newMarkets`, `experimental`, and `ethereum` categories.
	- Updated the `mainnetSlugs` to include the new entry `'wusdl-usdt'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->