### PR TITLE
chore: remove wmatic from verified pairs

### DIFF
--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -12,7 +12,6 @@ export const mainnetSlugs = [
   'autism-inj',
   'kira-inj',
   'arb-usdt',
-  'wmatic-usdt',
   'kava-usdt',
   'usdtkv-usdt',
   'tia-usdt',


### PR DESCRIPTION
remove wmatic spot from verified pairs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the entry `'wmatic-usdt'` from the mainnet slugs list to improve data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->