### PR TITLE
test: remove verified denom from explorer top result - skip redeploy

### DIFF
--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -52,6 +52,5 @@ export const testnetSlugs = [
   'projx-inj',
   'wbtc-usdt',
   'usdc-usdt',
-  'demo-usdt',
-  'test6-inj'
+  'demo-usdt'
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the entry `'test6-inj'` from the testnet slugs array to improve data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->