### PR TITLE
chore: bump 2024election perp to top of new markets list

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,11 +1,11 @@
 export const newMarkets = [
+  '2024election-perp',
   'moodeng-usdt-perp',
   'wusdl-usdt',
   'mother-usdt-perp',
   'apt-usdt-perp',
   'ton-usdt-perp',
   'ftm-usdt-perp',
-  '2024election-perp',
   'tao-usdt-perp',
   'popcat-usdt-perp',
   'pepe-usdt-perp',
@@ -31,9 +31,9 @@ export const newMarkets = [
 ]
 
 export const experimental = [
+  '2024election-perp',
   'moodeng-usdt-perp',
   'wusdl-usdt',
-  '2024election-perp',
   'buidl-usdt-perp',
   'ton-usdt',
   'btc-wusdm-perp',


### PR DESCRIPTION
bump 2024election perp to top of new markets list for election day promotion