### PR TITLE
chore: add fetusdt spot pair to fe

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'fet-usdt',
   'moodeng-usdt-perp',
   'wusdl-usdt',
   'mother-usdt-perp',
@@ -51,6 +52,7 @@ export const experimental = [
 
 export const cosmos = [
   'inj-usdt',
+  'fet-usdt',
   'cre-usdt',
   'tia-usdt',
   'stinj-inj',

--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -39,7 +39,8 @@ export const mainnetSlugs = [
   'ton-usdt',
   'xiii-inj',
   'hdro-usdt',
-  'wusdl-usdt'
+  'wusdl-usdt',
+  'fet-usdt'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
add fetusdt spot pair to fe verified and categories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the new market identifier `'fet-usdt'` in the market categories.
	- Updated the mainnet slug array to include the new entry `'fet-usdt'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->