### PR TITLE
add TruINJ data for testnet

### DIFF
--- a/ts-scripts/data/cw20.ts
+++ b/ts-scripts/data/cw20.ts
@@ -41,6 +41,10 @@ export const testnetTokens: Cw20TokenSource[] = [
   {
     ...symbolMeta.hINJ,
     address: 'inj1mz7mfhgx8tuvjqut03qdujrkzwlx9xhcj6yldc'
+  },
+  {
+    ...symbolMeta.TruINJ,
+    address: 'inj1zp0ac48kpp5cpu29p7a9wureydz7374h0wqy0a'
   }
 ]
 

--- a/ts-scripts/data/symbolMeta.ts
+++ b/ts-scripts/data/symbolMeta.ts
@@ -2069,5 +2069,13 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
     name: 'MANTRA',
     logo: 'om.webp',
     coinGeckoId: 'mantra-dao'
+  },
+
+  TruINJ: {
+    decimals: 18,
+    symbol: 'TruINJ',
+    name: 'TruFin liquid staking token',
+    logo: 'truinj.svg',
+    coinGeckoId: ''
   }
 }

--- a/ts-scripts/images/tokens/truinj.svg
+++ b/ts-scripts/images/tokens/truinj.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="600"
+   height="600"
+   viewBox="0 0 600 600"
+   fill="none"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="truINJ.svg"
+   inkscape:export-filename="../../../TruStake icons/truINJ-logo-200.png"
+   inkscape:export-xdpi="32"
+   inkscape:export-ydpi="32"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.4147721"
+     inkscape:cx="330.44192"
+     inkscape:cy="282.73106"
+     inkscape:window-width="1512"
+     inkscape:window-height="853"
+     inkscape:window-x="1036"
+     inkscape:window-y="1478"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5" />
+  <ellipse
+     style="opacity:1;fill:#59fab0;fill-opacity:1;stroke-width:1.87546;fill-rule:nonzero"
+     id="path6"
+     cx="299.65311"
+     cy="299.68958"
+     rx="200.92754"
+     ry="200.20757"
+     inkscape:label="path6" />
+  <path
+     d="M148.497 169.135C150.981 166.013 153.613 163.009 156.245 160.005C156.363 159.856 156.63 159.826 156.748 159.677C156.985 159.38 157.37 159.201 157.606 158.903L157.843 158.606C159.678 156.91 161.63 155.064 163.881 153.456C171.845 147.41 180.11 142.817 188.825 139.795C216.778 129.981 247.894 136.029 272.295 159.065C306.366 191.002 303.315 242.451 276.117 276.647C241.748 327.625 182.684 398.748 264.463 462.46C279.167 473.916 290.075 483.361 336.392 496.746C306.1 502.326 278.012 500.59 246.748 492.605C224.634 480.123 189.866 453.397 178.037 417.3C160.159 362.562 209.513 280.732 233.365 249.216C266.113 205.599 213.124 158.382 174.112 211.095C153.72 238.566 118.044 316.303 130.442 373.965C137.691 406.664 147.353 430.499 185.663 463.241C178.559 459.049 171.66 454.294 164.968 448.974C75.957 366.06 86.2838 237.859 148.497 169.135Z"
+     fill="url(#paint0_linear)"
+     id="path1"
+     style="fill:#0a0b28;fill-opacity:1" />
+  <path
+     d="M451.503 430.865C449.019 433.987 446.387 436.991 443.755 439.995C443.637 440.144 443.37 440.174 443.252 440.323C443.015 440.62 442.63 440.799 442.394 441.097L442.157 441.394C440.322 443.09 438.37 444.936 436.119 446.544C428.155 452.59 419.89 457.183 411.175 460.205C383.222 470.019 352.106 463.971 327.705 440.935C293.634 408.998 296.685 357.549 323.883 323.353C358.252 272.375 417.316 201.252 335.537 137.54C320.833 126.084 309.925 116.639 263.608 103.254C293.9 97.6736 321.988 99.4095 353.251 107.395C375.366 119.877 410.134 146.603 421.963 182.7C439.841 237.438 390.487 319.268 366.635 350.784C333.887 394.401 386.876 441.618 425.888 388.905C446.28 361.434 481.956 283.697 469.558 226.035C462.309 193.336 452.647 169.501 414.337 136.759C421.441 140.951 428.34 145.706 435.032 151.026C524.043 233.94 513.716 362.141 451.503 430.865Z"
+     fill="url(#paint1_linear)"
+     id="path2"
+     style="fill:#0a0b28;fill-opacity:1" />
+  <defs
+     id="defs5">
+    <linearGradient
+       id="paint0_linear"
+       x1="100"
+       y1="300"
+       x2="500"
+       y2="300"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#0082FA"
+         id="stop2" />
+      <stop
+         offset="1"
+         stop-color="#00F2FE"
+         id="stop3" />
+    </linearGradient>
+    <linearGradient
+       id="paint1_linear"
+       x1="100"
+       y1="300"
+       x2="500"
+       y2="300"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#0082FA"
+         id="stop4"
+         offset="0"
+         style="stop-color:#59fab0;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#00F2FE"
+         id="stop5" />
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
Hi, would it be possible to add the data for the TruINJ token on testnet?
Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the `TruINJ` token to the testnet configuration, increasing the variety of available tokens.
	- Introduced metadata for the `TruINJ` token, including its symbol, name, and logo. 

These additions enhance the token diversity for users interacting with the testnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->