### PR TITLE
chore: verify nonja and unverify crv perp

### DIFF
--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -7,7 +7,6 @@ export const mainnetSlugs: string[] = [
   'tao-usdt-perp',
   'popcat-usdt-perp',
   'pepe-usdt-perp',
-  'crv-usdt-perp',
   'mkr-usdt-perp',
   'aave-usdt-perp',
   'btc-usdt-perp',

--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -31,7 +31,8 @@ export const mainnetSlugs = [
   'xiii-inj',
   'hdro-usdt',
   'wusdl-usdt',
-  'fet-usdt'
+  'fet-usdt',
+  'nonja-inj'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
verify nonja and unverify crv perp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new entry `'nonja-inj'` to the mainnet slugs for spot market data.
  
- **Bug Fixes**
	- Removed the entry `'crv-usdt-perp'` from the mainnet slugs for derivative market data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->