### PR TITLE
chore: add xion perp to verified list

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -1,4 +1,5 @@
 export const newMarkets = [
+  'xion-usdt-perp',
   'fet-usdt',
   'moodeng-usdt-perp',
   'wusdl-usdt',
@@ -31,6 +32,7 @@ export const newMarkets = [
 ]
 
 export const experimental = [
+  'xion-usdt-perp',
   'moodeng-usdt-perp',
   'wusdl-usdt',
   'buidl-usdt-perp',
@@ -51,6 +53,7 @@ export const experimental = [
 ]
 
 export const cosmos = [
+  'xion-usdt-perp',
   'inj-usdt',
   'fet-usdt',
   'cre-usdt',

--- a/ts-scripts/data/market/derivative.ts
+++ b/ts-scripts/data/market/derivative.ts
@@ -1,4 +1,5 @@
 export const mainnetSlugs: string[] = [
+  'xion-usdt-perp',
   'moodeng-usdt-perp',
   'mother-usdt-perp',
   'apt-usdt-perp',


### PR DESCRIPTION
add xion perp to verified list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the market identifier `'xion-usdt-perp'` to the available market options in the `newMarkets`, `experimental`, and `cosmos` categories.
	- Added `'xion-usdt-perp'` to the `mainnetSlugs` array, expanding the available mainnet slugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->