### PR TITLE
chore: remove agent from fe

### DIFF
--- a/ts-scripts/data/market/spot.ts
+++ b/ts-scripts/data/market/spot.ts
@@ -32,8 +32,7 @@ export const mainnetSlugs = [
   'wusdl-usdt',
   'fet-usdt',
   'andr-usdt',
-  'nonja-inj',
-  'agent-inj'
+  'nonja-inj'
 ]
 
 export const devnetSlugs = ['proj-usdt', 'wbtc-inj', 'proj-inj']


### PR DESCRIPTION
 remove agent from fe until decimals fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the entry `'agent-inj'` from the mainnet slugs.
	- Re-added the entry `'nonja-inj'` to the mainnet slugs. 

These changes ensure that the correct market entries are available for users, enhancing the accuracy of market data displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->