### PR TITLE
add TruINJ's mainnet address

### DIFF
--- a/ts-scripts/data/cw20.ts
+++ b/ts-scripts/data/cw20.ts
@@ -304,5 +304,9 @@ export const mainnetTokens: Cw20TokenSource[] = [
   {
     ...symbolMeta.bnUSD,
     address: 'inj1qspaxnztkkzahvp6scq6xfpgafejmj2td83r9j'
+  },
+  {
+    ...symbolMeta.TruINJ,
+    address: 'inj1x997dy6ka7y8u0r56yk2k83llspy33yet9zcnq'
   }
 ]


### PR DESCRIPTION
Hi, we've just deployed our solution to mainnet after a successful governance vote.
Here I'm adding the address of our contract on mainnet.
Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new token, `TruINJ`, to the testnetTokens array, enhancing the available token options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->