### PR TITLE
Feat: add deprecate market ids list

### DIFF
--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -149,13 +149,6 @@ export const testnetCategoryMap = {
     '0xe185b08a7ccd830a94060edd5e457d30f429aa6f0757f75a8b93aa611780cfac' // gbp-usdt-perp
   ],
   deprecated: [],
-  experimental: [
-    '0xf02752c2c87728af7fd10a298a8a645261859eafd0295dcda7e2c5b45c8412cf', // stinj-inj
-    '0x2d7f47811527bd721ce2e4e0ff27b0f3a281f65abcd41758baf157c8ddfcd910', // hinj-inj
-    '0x637f6ec165c381ca4665935491b4d8a31fbc5cbc55616f1b5aafe8a64a2ebdda', // talis-inj
-    '0xd8e9ea042ac67990134d8e024a251809b1b76c5f7df49f511858e040a285efca' // hdro-inj
-  ],
-  // remove top above after launch
   trending: [],
   injective: [
     '0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe', // inj-usdt
@@ -182,7 +175,12 @@ export const devnetCategoryMap = {
   ],
   rwa: [],
   deprecated: [],
-  trending: [],
+  trending: [
+    '0x2d3b8d8833dda54a717adea9119134556848105fd6028e9a4a526e4e5a122a57', // kira-inj
+    '0x42edf70cc37e155e9b9f178e04e18999bc8c404bd7b638cc4cbf41da8ef45a21', // qunt-inj
+    '0xc8fafa1fcab27e16da20e98b4dc9dda45320418c27db80663b21edac72f3b597', // hdro-inj
+    '0xd166688623206f9931307285678e9ff17cecd80a27d7b781dd88cecfba3b1839' // black-inj
+  ],
   injective: [
     '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
     '0x7cc8b10d7deb61e744ef83bdec2bbcf4a056867e89b062c6a453020ca82bd4e4', // inj-usdt-perp
@@ -195,5 +193,10 @@ export const devnetCategoryMap = {
   layer2: [],
   defi: [],
   ai: [],
-  meme: []
+  meme: [
+    '0x2d3b8d8833dda54a717adea9119134556848105fd6028e9a4a526e4e5a122a57', // kira-inj
+    '0x42edf70cc37e155e9b9f178e04e18999bc8c404bd7b638cc4cbf41da8ef45a21', // qunt-inj
+    '0xc8fafa1fcab27e16da20e98b4dc9dda45320418c27db80663b21edac72f3b597', // hdro-inj
+    '0xd166688623206f9931307285678e9ff17cecd80a27d7b781dd88cecfba3b1839' // black-inj
+  ]
 }

--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -42,7 +42,34 @@ export const mainnetCategoryMap = {
     '0x3c5bba656074e6e84965dc7d99a218f6f514066e6ddc5046acaff59105bb6bf5', // eur-usdt-perp
     '0x5c0de20c02afe5dcc1c3c841e33bfbaa1144d8900611066141ad584eeaefbd2f' // gbp-usdt-perp
   ],
-  deprecated: [],
+  deprecated: [
+    '0xac938722067b1dfdfbf346d2434573fb26cb090d309b19af17df2c6827ceb32c', // sollegacy-usdt
+    '0x84ba79ffde31db8273a9655eb515cb6cadfdf451b8f57b83eb3f78dca5bbbe6d', // sollegacy-usdc
+    '0xcdfbfaf1f24055e89b3c7cc763b8cb46ffff08cdc38c999d01f58d64af75dca9', // aave-usdclegacy
+    '0xa43d2be9861efb0d188b136cef0ae2150f80e08ec318392df654520dd359fcd7', // grt-usdclegacy
+    '0xe0dc13205fb8b23111d8555a6402681965223135d368eeeb964681f9ff12eb2a', // inj-usdclegacy
+    '0xfe93c19c0a072c8dd208b96694e024305a7dff01bbf12cac2bfa81b246c69040', // link-usdclegacy
+    '0x5abfffe9079d53e0bf8ee9b3064b427acc3d71d6ba58a44235abe38f60115678', // matic-usdclegacy
+    '0x9a629b947b6f946af4f6076cfda67f3535d73ee3cef6176cf6d9c8d6b0a03f37', // sushi-usdclegacy
+    '0x09cc2c28fbedbdd677e07924653f8f583d0ee5886e74046e7f114210d990784b', // uni-usdclegacy
+    '0xf66f797a0ff49bd2170a04d288ca3f13b5df1c822a7b0cc4204aca64a5860666', // usdclegacy-usdcet
+    '0xabc20971099f5df5d1de138f8ea871e7e9832e3b0b54b61056eae15b09fed678', // usdclegacy-usdt
+    '0x8b1a4d3e8f6b559e30e40922ee3662dd78edf7042330d4d620d188699d1a9715', // usdt-usdclegacy
+    '0x170a06eb653548f67e94b0fcb82c5258c83b0a2b62ed24c55749d5ac77bc7621', // wbtc-usdclegacy
+    '0x01e920e081b6f3b2e5183399d5b6733bb6f80319e6be3805b95cb7236910ff0e', // weth-usdclegacy
+    '0x4fa0bd2c2adbfe077f58395c18a72f5cbf89532743e3bddf43bc7aba706b0b74', // chz-usdcet
+    '0x7fce43f1140df2e5f16977520629e32a591939081b59e8fbc1e1c4ddfa77a044', // usdcet-ldo
+    '0x66a113e1f0c57196985f8f1f1cfce2f220fa0a96bca39360c70b6788a0bc06e0', // ldo-usdcet
+    '0x84ba79ffde31db8273a9655eb515cb6cadfdf451b8f57b83eb3f78dca5bbbe6d', // sollegacy-usdc
+    '0xb825e2e4dbe369446e454e21c16e041cbc4d95d73f025c369f92210e82d2106f', // usdcso-usdcet
+    '0xf66f797a0ff49bd2170a04d288ca3f13b5df1c822a7b0cc4204aca64a5860666', // usdclegacy-usdcet
+    '0xda0bb7a7d8361d17a9d2327ed161748f33ecbf02738b45a7dd1d812735d1531c', // usdt-usdcet
+    '0xba33c2cdb84b9ad941f5b76c74e2710cf35f6479730903e93715f73f2f5d44be', // wmaticlegacy-usdc
+    '0x1bba49ea1eb64958a19b66c450e241f17151bc2e5ea81ed5e2793af45598b906', // arblegacy-usdt
+    '0xb9a07515a5c239fcbfa3e25eaa829a03d46c4b52b9ab8ee6be471e9eb0e9ea31', // wmaticlegacy-usdt
+    '0xb965ebede42e67af153929339040e650d5c2af26d6aa43382c110d943c627b0a', // pythlegacy-inj
+    '0xa6ec1de114a5ffa85b6b235144383ce51028a1c0c2dee7db5ff8bf14d5ca0d49' // pythlegacy-usdt
+  ],
   trending: [
     '0x5a9c0f24d6bdd55373ec3d20bfb5c041674bab183dfff0548d1c8fedbf243ca1', // xion-usdt
     '0x785afdbdc3aec238172294613c77fc129ebff1b2a0489375c30e69e6d3ac5325', // hype-usdt-perp
@@ -100,7 +127,7 @@ export const mainnetCategoryMap = {
     '0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced' // bnb-usdt-perp
   ],
   layer2: [
-    '0x1bba49ea1eb64958a19b66c450e241f17151bc2e5ea81ed5e2793af45598b906', // arb-usdt
+    '0x1c2e5b1b4b1269ff893b4817a478fba6095a89a3e5ce0cccfcafa72b3941eeb6', // arb-usdt
     '0x6ddf0b8fbbd888981aafdae9fc967a12c6777aac4dd100a8257b8755c0c4b7d5', // arb-usdt-perp
     '0x48fcecd66ebabbf5a331178ec693b261dfae66ddfe6f552d7446744c6e78046c' // op-usdt-perp
   ],

--- a/ts-scripts/data/market/category.ts
+++ b/ts-scripts/data/market/category.ts
@@ -36,126 +36,13 @@ export const mainnetCategoryMap = {
     '0xacb0dc21cddb15b686f36c3456f4223f701a2afa382006ef478d156439483b4d', // ezeth-weth
     '0x960038a93b70a08f1694c4aa5c914afda329063191e65a5b698f9d0676a0abf9' // saga-usd
   ],
-  cosmos: [
-    '0x5a9c0f24d6bdd55373ec3d20bfb5c041674bab183dfff0548d1c8fedbf243ca1', // xion-usdt
-    '0x372b5c987fe8f7f84ced0d019e7ee24353877ad8cf93235ba98c970de001b3fd', // xion-usdt-perp
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
-    '0xc9030edef611568ec9aa48228c92e30d398abf0eb289b5fee873b0f2f3a80295', // fet-usdt
-    '0xe03df6e1571acb076c3d8f22564a692413b6843ad2df67411d8d8e56449c7ff4', // cre-usdt
-    '0x35fd4fa9291ea68ce5eef6e0ea8567c7744c1891c2059ef08580ba2e7a31f101', // tia-usdt
-    '0xce1829d4942ed939580e72e66fd8be3502396fc840b6d12b2d676bdb86542363', // stinj-inj
-    '0x0686357b934c761784d58a2b8b12618dfe557de108a220e06f8f6580abb83aab', // somm-usdt
-    '0xa7fb70ac87e220f3ea7f7f77faf48b47b3575a9f7ad22291f04a02799e631ca9', // canto-usdt
-    '0xcd4b823ad32db2245b61bf498936145d22cdedab808d2f9d65100330da315d29', // strd-usdt
-    '0x9b9980167ecc3645ff1a5517886652d94a0825e54a77d2057cbbe3ebee015963', // inj-usdt-perp
-    '0xc559df216747fc11540e638646c384ad977617d6d8f0ea5ffdfc18d52e58ab01', // atom-usdt-perp
-    '0x1afa358349b140e49441b6e68529578c7d2f27f06e18ef874f428457c0aaeb8b', // sei-usdt-perp
-    '0x4fe7aff4dd27be7cbb924336e7fe2d160387bb1750811cf165ce58d4c612aebb', // axl-usdt-perp
-    '0x9066bfa1bd97685e0df4e22a104f510fb867fde7f74a52f3341c7f5f56eb889c', // tia-usdt-perp
-    '0x21f3eed62ddc64458129c0dcbff32b3f54c92084db787eb5cf7c20e69a1de033', // talis-usdt
-    '0xcf18525b53e54ad7d27477426ade06d69d8d56d2f3bf35fe5ce2ad9eb97c2fbc', // osmo-usdt-perp
-    '0x959c9401a557ac090fff3ec11db5a1a9832e51a97a41b722d2496bb3cb0b2f72', // andr-inj
-    '0x586409ac5f6d6e90a81d2585b9a8e76de0b4898d5f2c047d0bc025a036489ba1', // whale-inj
-    '0x960038a93b70a08f1694c4aa5c914afda329063191e65a5b698f9d0676a0abf9', // saga-usdt
-    '0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa', // atom-usdt
-    '0x75f6a79b552dac417df219ab384be19cb13b53dec7cf512d73a965aee8bc83af' // usdy-usdt
-  ],
-  ethereum: [
-    '0xb5d3a9c31f992f995baf25cbdeddd713dd4ae7be7be65ea8dd5ddff86b2090c8', // wusdl-usdt
-    '0xc4068b76801bf8988b5372c64d611ce2a477f85512e5ec55270c426176bc73e2', // ton-usdt-perp
-    '0x2d7092545081b81ba33bf817b302f9609254f15f4354016631aec3bb39461f99', // pepe-usdt-perp
-    '0xf58079e67f845907e93ab9767126a226a0759c23bee1bfc880fa8fba98f25872', // crv-usdt-perp
-    '0x142d0fa4506b5f404bcfdd54567797ff6767dce07afaedc90d379665f09f0520', // mkr-usdt-perp
-    '0x84d6fad5c0450811f8c163560e90ba7f621506371ec17fb07885dda2a6f435ed', // aave-usdt-perp
-    '0x639fb43887ededd06e28f3c0d0dec62caca5c4e1cac31765f19af07c4ad999c2', // buidl-usdt-perp
-    '0x165b41ab4410c03514b4569b29dd3c4a829f6f11516a29cd31d6a53308cb4ed0', // ton-usdt
-    '0xca8121ea57a4f7fd3e058fa1957ebb69b37d52792e49b0b43932f1b9c0e01f8b', // wusdm-usdt
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
-    '0x1bba49ea1eb64958a19b66c450e241f17151bc2e5ea81ed5e2793af45598b906', // arb-usdt
-    '0xd0ba680312852ffb0709446fff518e6c4d798fb70cfd2699aba3717a2517cfd5', // app-inj
-    '0x572f05fd93a6c2c4611b2eba1a0a36e102b6a592781956f0128a27662d84f112', // ape-usdt
-    '0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31', // link-usdt
-    '0xce1829d4942ed939580e72e66fd8be3502396fc840b6d12b2d676bdb86542363', // stinj-inj
-    '0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034', // weth-usdt
-    '0x8cd25fdc0d7aad678eb998248f3d1771a2d27c964a7630e6ffa5406de7ea54c1', // wmatic-usdt
-    '0x219b522871725d175f63d5cb0a55e95aa688b1c030272c5ae967331e45620032', // steadyeth-usdt
-    '0x510855ccf9148b47c6114e1c9e26731f9fd68a6f6dbc5d148152d02c0f3e5ce0', // steadybtc-usdt
-    '0x9b9980167ecc3645ff1a5517886652d94a0825e54a77d2057cbbe3ebee015963', // inj-usdt-perp
-    '0x54d4505adef6a5cef26bc403a33d595620ded4e15b9e2bc3dd489b714813366a', // eth-usdt-perp
-    '0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced', // bnb-usdt-perp
-    '0x6ddf0b8fbbd888981aafdae9fc967a12c6777aac4dd100a8257b8755c0c4b7d5', // arb-usdt-perp
-    '0x48fcecd66ebabbf5a331178ec693b261dfae66ddfe6f552d7446744c6e78046c', // op-usdt-perp
-    '0x03c8da1f6aaf8aca2be26b0f4d6b89d475835c7812a1dcdb19af7dec1c6b7f60', // link-usdt-perp
-    '0x6ad662364885b8a4c50edfc88deeef23338b2bd0c1e4dc9b680b054afc9b6b24', // ena-usdt
-    '0x35a83ec8948babe4c1b8fbbf1d93f61c754fedd3af4d222fe11ce2a294cd74fb', // w-usdt
-    '0xf1bc70398e9b469db459f3153433c6bd1253bd02377248ee29bd346a218e6243', // w-usdt-perp
-    '0x2be72879bb90ec8cbbd7510d0eed6a727f6c2690ce7f1397982453d552f9fe8f', // omni-usdt
-    '0x71dc35acfd9fffe3f2995fdcd6f6abb3c2713e63824b2e45c39e8b4275ea931d' // pyusd-usd
-  ],
-  solana: [
-    '0x26e978947835ce9d686d5345dec98e2c356aa17b371886dfb5a05e9bafbd89e8', // chillguy-usdt-perp
-    '0x65bba95527630a9648d808ebe0e7b6e0c47d1ba0283a396bd5335e4d1997d85f', // moodeng-usdt-perp
-    '0xa9ff3263c6a23bd1effb92f663bd8a1c9f9fa25f83f02c45364f92d77473827b', // mother-usdt-perp
-    '0x8157dd4bf502fc688aaa722c725124da3f411d7a92c569d55f34826f9ee040a9', // popcat-usdt-perp
-    '0x03841e74624fd885d1ee28453f921d18c211e78a0d7646c792c7903054eb152c', // jup-usdt-perp
-    '0x887beca72224f88fb678a13a1ae91d39c53a05459fd37ef55005eb68f745d46d', // pyth-usdt-perp
-    '0xac938722067b1dfdfbf346d2434573fb26cb090d309b19af17df2c6827ceb32c', // sol-usdt
-    '0x06c5a306492ddc2b8dc56969766959163287ed68a6b59baa2f42330dda0aebe0', // sol-usdt-perp
-    '0x1a6d3a59f45904e0a4a2eed269fc2f552e7e407ac90aaaeb602c31b017573f88', // wif-usdt-perp
-    '0x35a83ec8948babe4c1b8fbbf1d93f61c754fedd3af4d222fe11ce2a294cd74fb', // w-usdt
-    '0xf1bc70398e9b469db459f3153433c6bd1253bd02377248ee29bd346a218e6243', // w-usdt-perp
-    '0xb232d5bc92bd64cf01741bf01e831566bbd517540dbca8fb420f772f9807f977', // sns-inj
-    '0xd6518f94efd32d7129eea0780d256a714d41a1f02992f346342bd64dc26a7217' // giga-inj
-  ],
-  olpLowVolume: [
-    '0xc8fafa1fcab27e16da20e98b4dc9dda45320418c27db80663b21edac72f3b597', // 'hdro-inj',
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // 'inj-usdt',
-    '0x35fd4fa9291ea68ce5eef6e0ea8567c7744c1891c2059ef08580ba2e7a31f101', // 'tia-usdt',
-    '0x63bafbeee644b6606afb8476dd378fba35d516c7081d6045145790af963545aa', // 'xrp-usdt-perp',
-    '0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa', // 'atom-usdt',
-    '0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034', // 'weth-usdt',
-    '0x8cd25fdc0d7aad678eb998248f3d1771a2d27c964a7630e6ffa5406de7ea54c1', // 'wmatic-usdt',
-    '0xc559df216747fc11540e638646c384ad977617d6d8f0ea5ffdfc18d52e58ab01', // 'atom-usdt-perp',
-    '0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce', // 'btc-usdt-perp',
-    '0x54d4505adef6a5cef26bc403a33d595620ded4e15b9e2bc3dd489b714813366a', // 'eth-usdt-perp',
-    '0x9b9980167ecc3645ff1a5517886652d94a0825e54a77d2057cbbe3ebee015963', // 'inj-usdt-perp',
-    '0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced', // 'bnb-usdt-perp',
-    '0x887beca72224f88fb678a13a1ae91d39c53a05459fd37ef55005eb68f745d46d', // 'pyth-usdt-perp',
-    '0xac938722067b1dfdfbf346d2434573fb26cb090d309b19af17df2c6827ceb32c', // 'sol-usdt',
-    '0x4fe7aff4dd27be7cbb924336e7fe2d160387bb1750811cf165ce58d4c612aebb', // 'axl-usdt-perp',
-    '0x2d8b2a2bef3782b988e16a8d718ea433d6dfebbb3b932975ca7913589cb408b5', // 'kava-usdt',
-    '0x1afa358349b140e49441b6e68529578c7d2f27f06e18ef874f428457c0aaeb8b', // 'sei-usdt-perp',
-    '0x9066bfa1bd97685e0df4e22a104f510fb867fde7f74a52f3341c7f5f56eb889c' // 'tia-usdt-perp'
-  ],
-  experimental: [
-    '0x785afdbdc3aec238172294613c77fc129ebff1b2a0489375c30e69e6d3ac5325', // hype-usdt-perp
-    '0x26e978947835ce9d686d5345dec98e2c356aa17b371886dfb5a05e9bafbd89e8', // chillguy-usdt-perp
-    '0x372b5c987fe8f7f84ced0d019e7ee24353877ad8cf93235ba98c970de001b3fd', // xion-usdt-per
-    '0x65bba95527630a9648d808ebe0e7b6e0c47d1ba0283a396bd5335e4d1997d85f', // moodeng-usdt-perp
-    '0xb5d3a9c31f992f995baf25cbdeddd713dd4ae7be7be65ea8dd5ddff86b2090c8', // wusdl-usdt
-    '0x639fb43887ededd06e28f3c0d0dec62caca5c4e1cac31765f19af07c4ad999c2', // buidl-usdt-perp
-    '0x165b41ab4410c03514b4569b29dd3c4a829f6f11516a29cd31d6a53308cb4ed0', // ton-usdt
-    '0x0d4c722badb032f14dfc07355258a4bcbd354cbc5d79cb5b69ddd52b1eb2f709', // btc-wusdm-perp
-    '0xca8121ea57a4f7fd3e058fa1957ebb69b37d52792e49b0b43932f1b9c0e01f8b', // wusdm-usdt
-    '0x75f6a79b552dac417df219ab384be19cb13b53dec7cf512d73a965aee8bc83af', // usdy-usdt
-    '0x1af8fa374392dc1bd6331f38f0caa424a39b05dd9dfdc7a2a537f6f62bde50fe', // usde-usdt
-    '0xd0ba680312852ffb0709446fff518e6c4d798fb70cfd2699aba3717a2517cfd5', // app-inj
-    '0x03841e74624fd885d1ee28453f921d18c211e78a0d7646c792c7903054eb152c', // jup-usdt-perp
-    '0x0a1366c8b05658c0ccca6064e4b20aacd5ad350c02debd6ec0f4dc9178145d14', // gyen-usdt
-    '0x1a6d3a59f45904e0a4a2eed269fc2f552e7e407ac90aaaeb602c31b017573f88', // wif-usdt-perp
-    '0x42edf70cc37e155e9b9f178e04e18999bc8c404bd7b638cc4cbf41da8ef45a21', // qunt-inj
-    '0x4d42425fc3ccd6b61b8c4ad61134ab3cf21bdae1b665317eff671cfab79f4387', // omni-usdt-perp
-    '0xf1bc70398e9b469db459f3153433c6bd1253bd02377248ee29bd346a218e6243', // w-usdt-perp
-    '0x9b3fa54bef33fd216b84614cd8abc3e5cc134727a511cef37d366ecaf3e03a80', // mother-inj
-    '0x315e5cd5ee24b3a1e1396679885b5e42bbe18045105d1662c6618430a131d117' // xiii-inj
-  ],
   rwa: [
     '0x0160a0c8ecbf5716465b9fc22bceeedf6e92dcdc688e823bbe1af3b22a84e5b5', // xau-usdt-perp
     '0xedc48ec071136eeb858b11ba50ba87c96e113400e29670fecc0a18d588238052', // xag-usdt-perp
     '0x3c5bba656074e6e84965dc7d99a218f6f514066e6ddc5046acaff59105bb6bf5', // eur-usdt-perp
     '0x5c0de20c02afe5dcc1c3c841e33bfbaa1144d8900611066141ad584eeaefbd2f' // gbp-usdt-perp
   ],
-  // remove top above after launch
+  deprecated: [],
   trending: [
     '0x5a9c0f24d6bdd55373ec3d20bfb5c041674bab183dfff0548d1c8fedbf243ca1', // xion-usdt
     '0x785afdbdc3aec238172294613c77fc129ebff1b2a0489375c30e69e6d3ac5325', // hype-usdt-perp
@@ -255,70 +142,13 @@ export const testnetCategoryMap = {
     '0x155576f660b3b6116c1ab7a42fbf58a95adf11b3061f88f81bc8df228e7ac934', // xau-usdt-perp
     '0x0f03542809143c7e5d3c22f56bc6e51eb2c8bab5009161b58f6f468432dfa196' // xag-usdt-perp
   ],
-  cosmos: [
-    '0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe', // inj-usdt
-    '0xa283fc94a9055a01a58bb6229b1e56a8bb54069a0debfce7fbd1e6c25a95330c', // tia-usdt
-    '0xf02752c2c87728af7fd10a298a8a645261859eafd0295dcda7e2c5b45c8412cf', // stinj-inj
-    '0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6', // inj-usdt-perp
-    '0xd97d0da6f6c11710ef06315971250e4e9aed4b7d4cd02059c9477ec8cf243782', // atom-usdt-perp
-    '0xc90e8ea048b8fe5c3174d4d0386191765db699d2bf83d0cbaf07e15462115a15', // tia-usdt-perp
-    '0x670e5881decd6a2c1673133efe4b99ceb4623698509f26c64fcc03fa7a2cb777', // talis-usdt
-    '0x491ee4fae7956dd72b6a97805046ffef65892e1d3254c559c18056a519b2ca15' // atom-usdt
-  ],
-  ethereum: [
-    '0xb5d3a9c31f992f995baf25cbdeddd713dd4ae7be7be65ea8dd5ddff86b2090c8', // wusdl-usdt
-    '0xc4068b76801bf8988b5372c64d611ce2a477f85512e5ec55270c426176bc73e2', // ton-usdt-perp
-    '0x2d7092545081b81ba33bf817b302f9609254f15f4354016631aec3bb39461f99', // pepe-usdt-perp
-    '0xf58079e67f845907e93ab9767126a226a0759c23bee1bfc880fa8fba98f25872', // crv-usdt-perp
-    '0x142d0fa4506b5f404bcfdd54567797ff6767dce07afaedc90d379665f09f0520', // mkr-usdt-perp
-    '0x84d6fad5c0450811f8c163560e90ba7f621506371ec17fb07885dda2a6f435ed', // aave-usdt-perp
-    '0x639fb43887ededd06e28f3c0d0dec62caca5c4e1cac31765f19af07c4ad999c2', // buidl-usdt-perp
-    '0x165b41ab4410c03514b4569b29dd3c4a829f6f11516a29cd31d6a53308cb4ed0', // ton-usdt
-    '0xca8121ea57a4f7fd3e058fa1957ebb69b37d52792e49b0b43932f1b9c0e01f8b', // wusdm-usdt
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
-    '0x1bba49ea1eb64958a19b66c450e241f17151bc2e5ea81ed5e2793af45598b906', // arb-usdt
-    '0xd0ba680312852ffb0709446fff518e6c4d798fb70cfd2699aba3717a2517cfd5', // app-inj
-    '0x572f05fd93a6c2c4611b2eba1a0a36e102b6a592781956f0128a27662d84f112', // ape-usdt
-    '0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31', // link-usdt
-    '0xce1829d4942ed939580e72e66fd8be3502396fc840b6d12b2d676bdb86542363', // stinj-inj
-    '0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034', // weth-usdt
-    '0x8cd25fdc0d7aad678eb998248f3d1771a2d27c964a7630e6ffa5406de7ea54c1', // wmatic-usdt
-    '0x219b522871725d175f63d5cb0a55e95aa688b1c030272c5ae967331e45620032', // steadyeth-usdt
-    '0x510855ccf9148b47c6114e1c9e26731f9fd68a6f6dbc5d148152d02c0f3e5ce0', // steadybtc-usdt
-    '0x9b9980167ecc3645ff1a5517886652d94a0825e54a77d2057cbbe3ebee015963', // inj-usdt-perp
-    '0x54d4505adef6a5cef26bc403a33d595620ded4e15b9e2bc3dd489b714813366a', // eth-usdt-perp
-    '0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced', // bnb-usdt-perp
-    '0x6ddf0b8fbbd888981aafdae9fc967a12c6777aac4dd100a8257b8755c0c4b7d5', // arb-usdt-perp
-    '0x48fcecd66ebabbf5a331178ec693b261dfae66ddfe6f552d7446744c6e78046c', // op-usdt-perp
-    '0x03c8da1f6aaf8aca2be26b0f4d6b89d475835c7812a1dcdb19af7dec1c6b7f60', // link-usdt-perp
-    '0x6ad662364885b8a4c50edfc88deeef23338b2bd0c1e4dc9b680b054afc9b6b24', // ena-usdt
-    '0x35a83ec8948babe4c1b8fbbf1d93f61c754fedd3af4d222fe11ce2a294cd74fb', // w-usdt
-    '0xf1bc70398e9b469db459f3153433c6bd1253bd02377248ee29bd346a218e6243', // w-usdt-perp
-    '0x2be72879bb90ec8cbbd7510d0eed6a727f6c2690ce7f1397982453d552f9fe8f', // omni-usdt
-    '0x71dc35acfd9fffe3f2995fdcd6f6abb3c2713e63824b2e45c39e8b4275ea931d' // pyusd-usd
-  ],
-  solana: [
-    '0x2da41d4f7370e6d44240480bae530661ba3ae68682089810ea29beee1984985f', // sol-usdt
-    '0x95698a9d8ba11660f44d7001d8c6fb191552ece5d9141a05c5d9128711cdc2e0' // sol-usdt-perp
-  ],
-  olpLowVolume: [
-    '0xd8e9ea042ac67990134d8e024a251809b1b76c5f7df49f511858e040a285efca', // hdro-inj
-    '0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe', // inj-usdt
-    '0xa283fc94a9055a01a58bb6229b1e56a8bb54069a0debfce7fbd1e6c25a95330c', // tia-usdt
-    '0x491ee4fae7956dd72b6a97805046ffef65892e1d3254c559c18056a519b2ca15', // atom-usdt
-    '0xa97182f11f1aa5339c7f4c3fe3cc1c69b39079f11b864c86d912956c5c2db75c', // weth-usdt
-    '0xd97d0da6f6c11710ef06315971250e4e9aed4b7d4cd02059c9477ec8cf243782', // atom-usdt-perp
-    '0x70bc8d7feab38b23d5fdfb12b9c3726e400c265edbcbf449b6c80c31d63d3a02', // eth-usdt-perp
-    '0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6', // inj-usdt-perp
-    '0x2da41d4f7370e6d44240480bae530661ba3ae68682089810ea29beee1984985f', // sol-usdt
-    '0xc90e8ea048b8fe5c3174d4d0386191765db699d2bf83d0cbaf07e15462115a15' // tia-usdt-perp
-  ],
   rwa: [
     '0x155576f660b3b6116c1ab7a42fbf58a95adf11b3061f88f81bc8df228e7ac934', // xau-usdt-perp
     '0x0f03542809143c7e5d3c22f56bc6e51eb2c8bab5009161b58f6f468432dfa196', // xag-usdt-perp
     '0xb6fd8f78b97238eb67146e9b097c131e94730c10170cbcafa82ea2fd14ff62c7', // eur-usdt-perp
     '0xe185b08a7ccd830a94060edd5e457d30f429aa6f0757f75a8b93aa611780cfac' // gbp-usdt-perp
   ],
+  deprecated: [],
   experimental: [
     '0xf02752c2c87728af7fd10a298a8a645261859eafd0295dcda7e2c5b45c8412cf', // stinj-inj
     '0x2d7f47811527bd721ce2e4e0ff27b0f3a281f65abcd41758baf157c8ddfcd910', // hinj-inj
@@ -350,41 +180,8 @@ export const devnetCategoryMap = {
     '0xc8fafa1fcab27e16da20e98b4dc9dda45320418c27db80663b21edac72f3b597', // hdro-inj
     '0xd166688623206f9931307285678e9ff17cecd80a27d7b781dd88cecfba3b1839' // black-inj
   ],
-  cosmos: [
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
-    '0x0686357b934c761784d58a2b8b12618dfe557de108a220e06f8f6580abb83aab', // somm-usdt
-    '0x7cc8b10d7deb61e744ef83bdec2bbcf4a056867e89b062c6a453020ca82bd4e4', // inj-usdt-perp
-    '0x56d0c0293c4415e2d48fc2c8503a56a0c7389247396a2ef9b0a48c01f0646705', // atom-usdt-perp
-    '0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa' // atom-usdt
-  ],
-  ethereum: [
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
-    '0x572f05fd93a6c2c4611b2eba1a0a36e102b6a592781956f0128a27662d84f112', // ape-usdt
-    '0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31', // link-usdt
-    '0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034', // weth-usdt
-    '0x7cc8b10d7deb61e744ef83bdec2bbcf4a056867e89b062c6a453020ca82bd4e4', // inj-usdt-perp
-    '0x3b7fb1d9351f7fa2e6e0e5a11b3639ee5e0486c33a6a74f629c3fc3c3043efd5', // bonk-usdt-perp
-    '0x979731deaaf17d26b2e256ad18fecd0ac742b3746b9ea5382bac9bd0b5e58f74', // eth-usdt-perp
-    '0x1f73e21972972c69c03fb105a5864592ac2b47996ffea3c500d1ea2d20138717' // link-usdt-perp
-  ],
-  solana: [
-    '0x3b7fb1d9351f7fa2e6e0e5a11b3639ee5e0486c33a6a74f629c3fc3c3043efd5' // bonk-usdt-perp
-  ],
-  olpLowVolume: [
-    '0xc8fafa1fcab27e16da20e98b4dc9dda45320418c27db80663b21edac72f3b597', // hdro-inj
-    '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt
-    '0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa', // atom-usdt
-    '0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034', // weth-usdt
-    '0x56d0c0293c4415e2d48fc2c8503a56a0c7389247396a2ef9b0a48c01f0646705', // atom-usdt-perp
-    '0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce', // btc-usdt-perp
-    '0x979731deaaf17d26b2e256ad18fecd0ac742b3746b9ea5382bac9bd0b5e58f74', // eth-usdt-perp
-    '0x7cc8b10d7deb61e744ef83bdec2bbcf4a056867e89b062c6a453020ca82bd4e4' // inj-usdt-perp
-  ],
   rwa: [],
-  experimental: [
-    '0x42edf70cc37e155e9b9f178e04e18999bc8c404bd7b638cc4cbf41da8ef45a21' // qunt-inj
-  ],
-  // remove top above after launch
+  deprecated: [],
   trending: [],
   injective: [
     '0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0', // inj-usdt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `deprecated` category to streamline market identifiers.
	- Updated `trending` and `injective` categories with new entries.

- **Bug Fixes**
	- Removed outdated categories (`cosmos`, `ethereum`, `solana`, `olpLowVolume`, `experimental`) to enhance clarity in market mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->