### PR TITLE
fix spx metadata back to correct standard

### DIFF
--- a/ts-scripts/data/untaggedSymbolMeta.ts
+++ b/ts-scripts/data/untaggedSymbolMeta.ts
@@ -327,10 +327,10 @@ export const untaggedSymbolMeta = {
     coinGeckoId: 'aethir'
   },
 
-  SPX6900: {
+  SPX: {
     name: 'SPX6900',
     decimals: 6,
-    symbol: 'SPX6900',
+    symbol: 'SPX',
     logo: 'spx6900.webp',
     coinGeckoId: 'spx6900'
   }


### PR DESCRIPTION
fix spx metadata back to correct standard - name is SPX6900, ticker is SPX