### PR TITLE
chore: add ausd/usdt and ausd/usdc sgt

### DIFF
--- a/ts-scripts/data/grid/spot.ts
+++ b/ts-scripts/data/grid/spot.ts
@@ -166,6 +166,10 @@ export const mainnetGridMarkets = [
   {
     slug: 'nept-inj',
     contractAddress: 'inj1tywtf22sw8h4cd5v36gp0u3uya2psm0s8lxxan'
+  },
+  {
+    slug: 'ausd-usdt',
+    contractAddress: 'inj177dqntky3fggrpf7t7qq7j89gmfqmzz4y5t2fh'
   }
 ]
 

--- a/ts-scripts/data/grid/spot.ts
+++ b/ts-scripts/data/grid/spot.ts
@@ -170,6 +170,10 @@ export const mainnetGridMarkets = [
   {
     slug: 'ausd-usdt',
     contractAddress: 'inj177dqntky3fggrpf7t7qq7j89gmfqmzz4y5t2fh'
+  },
+  {
+    slug: 'ausd-usdc',
+    contractAddress: 'inj1vhpuluzljqk7meej5l943sflds6xfc78as5xvm'
   }
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new market entries for 'ausd-usdt' and 'ausd-usdc' to the mainnet grid markets list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->