### PR TITLE
chore: move xaug and xag market category

### DIFF
--- a/src/data/market/category.ts
+++ b/src/data/market/category.ts
@@ -15,8 +15,6 @@ export const mainnetCategoryMap = {
   ],
   rwa: [
     // RWA
-    '0x0160a0c8ecbf5716465b9fc22bceeedf6e92dcdc688e823bbe1af3b22a84e5b5', // xau-usdt-perp
-    '0xedc48ec071136eeb858b11ba50ba87c96e113400e29670fecc0a18d588238052', // xag-usdt-perp
     '0x3c5bba656074e6e84965dc7d99a218f6f514066e6ddc5046acaff59105bb6bf5', // eur-usdt-perp
     '0x5c0de20c02afe5dcc1c3c841e33bfbaa1144d8900611066141ad584eeaefbd2f' // gbp-usdt-perp
   ],
@@ -30,7 +28,9 @@ export const mainnetCategoryMap = {
     '0x056fd86c5b8bde4a4f03552e281db86fc6c110a13a79b98b2011aa84bb0ec340', // imcd-usdt-perp
     '0x37d4e69a77cdca055615d55c088d5bdf1bc75801e2c00a925e0b2dae62b5d660', // tti-usdt-perp
     '0x1e8369b298705c468c1a313a729bae0dbd4410587465cc69276bf8ba4e0231c1', // invda-usdt-perp
-    '0x2236b4cd97300c79fca5c2fff4b647ab24a6d48c1554255ff8ec7cf29429ba74' // tradfi-usdt-perp
+    '0x2236b4cd97300c79fca5c2fff4b647ab24a6d48c1554255ff8ec7cf29429ba74', // tradfi-usdt-perp
+    '0x0160a0c8ecbf5716465b9fc22bceeedf6e92dcdc688e823bbe1af3b22a84e5b5', // xau-usdt-perp
+    '0xedc48ec071136eeb858b11ba50ba87c96e113400e29670fecc0a18d588238052' // xag-usdt-perp
   ],
   deprecated: [
     '0xac938722067b1dfdfbf346d2434573fb26cb090d309b19af17df2c6827ceb32c', // sollegacy-usdt

--- a/src/data/market/spot.ts
+++ b/src/data/market/spot.ts
@@ -63,8 +63,8 @@ export const stagingMarketIds = [
 ]
 
 export const testnetMarketIds = [
-  '0xa283fc94a9055a01a58bb6229b1e56a8bb54069a0debfce7fbd1e6c25a95330c', // tia-usdt
   '0x491ee4fae7956dd72b6a97805046ffef65892e1d3254c559c18056a519b2ca15', // atom-usdt
+  '0xa283fc94a9055a01a58bb6229b1e56a8bb54069a0debfce7fbd1e6c25a95330c', // tia-usdt
   '0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe', // inj-usdt
   '0x1c315bd2cfcc769a8d8eca49ce7b1bc5fb0353bfcb9fa82895fe0c1c2a62306e', // wbtc-usdt
   '0xa97182f11f1aa5339c7f4c3fe3cc1c69b39079f11b864c86d912956c5c2db75c', // weth-usdt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reassigned two market IDs from the "rwa" category to the "iAssets" category.
  - Updated the order of market IDs in the testnet market list for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->