### PR TITLE
chore: update usd1 name

### DIFF
--- a/src/data/tokens/symbolMeta.ts
+++ b/src/data/tokens/symbolMeta.ts
@@ -2177,7 +2177,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
 
   USD1: {
     decimals: 18,
-    name: 'World Liberty Financial Dollar',
+    name: 'World Liberty Financial USD',
     logo: 'usd1.webp',
     symbol: 'USD1',
     coinGeckoId: 'usd1-wlfi'


### PR DESCRIPTION
update usd1 name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the display name for the USD1 token to "World Liberty Financial USD".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->