### PR TITLE
chore: edit truinj meta

### DIFF
--- a/src/data/tokens/cw20.ts
+++ b/src/data/tokens/cw20.ts
@@ -41,10 +41,6 @@ export const testnetTokens: Cw20TokenSource[] = [
   {
     ...symbolMeta.hINJ,
     address: 'inj1mz7mfhgx8tuvjqut03qdujrkzwlx9xhcj6yldc'
-  },
-  {
-    ...symbolMeta.TruINJ,
-    address: 'inj1zp0ac48kpp5cpu29p7a9wureydz7374h0wqy0a'
   }
 ]
 

--- a/src/data/tokens/symbolMeta.ts
+++ b/src/data/tokens/symbolMeta.ts
@@ -2074,7 +2074,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
   TruINJ: {
     decimals: 18,
     symbol: 'TruINJ',
-    name: 'TruFin Liquid Staking Token',
+    name: 'TruFin Staked INJ',
     logo: 'truinj.svg',
     coinGeckoId: ''
   },


### PR DESCRIPTION
edit truinj meta, remove from cw20.ts as its tokenfactory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the TruINJ token from the testnet token list.

- **Style**
  - Updated the display name for the TruINJ token to "TruFin Staked INJ".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->