### PR TITLE
feat: disable chainupgrade maintenance mode

### DIFF
--- a/src/data/config/index.ts
+++ b/src/data/config/index.ts
@@ -11,7 +11,7 @@ const LyoraMainnetUpgrade = {
 export const chainUpgradeConfig = {
   proposalId: 541,
   blockHeight: 127250000,
-  disableMaintenance: false,
+  disableMaintenance: true,
   proposalMsg:
     'Scheduled maintenance on July 31st, 2025 at ~14:00 UTC to implement the Injective EVM mainnet upgrade.'
 } as ChainConfig | {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance mode will be enabled for the Injective EVM mainnet upgrade scheduled on July 31st, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->