### PR TITLE
chore: update iasset base tickers

### DIFF
--- a/src/data/tokens/untaggedSymbolMeta.ts
+++ b/src/data/tokens/untaggedSymbolMeta.ts
@@ -423,10 +423,10 @@ export const untaggedSymbolMeta = {
     coinGeckoId: 'kaito'
   },
 
-  iNVDA: {
+  NVDA: {
     name: 'NVIDIA',
     decimals: 6,
-    symbol: 'iNVDA',
+    symbol: 'NVDA',
     logo: 'nvidia.webp',
     coinGeckoId: ''
   },
@@ -455,42 +455,42 @@ export const untaggedSymbolMeta = {
     coinGeckoId: ''
   },
 
-  iHOOD: {
+  HOOD: {
     name: 'Robinhood',
     decimals: 6,
-    symbol: 'iHOOD',
+    symbol: 'HOOD',
     logo: 'ihood.webp',
     coinGeckoId: ''
   },
   
-  iMSTR: {
+  MSTR: {
     name: 'Strategy',
     decimals: 6,
-    symbol: 'iMSTR',
+    symbol: 'MSTR',
     logo: 'mstr.webp',
     coinGeckoId: ''
   },
 
-  iCOIN: {
+  COIN: {
     name: 'Coinbase',
     decimals: 6,
-    symbol: 'iCOIN',
+    symbol: 'COIN',
     logo: 'coin.webp',
     coinGeckoId: ''
   },
 
-  iTSLA: {
+  TSLA: {
     name: 'Tesla',
     decimals: 6,
-    symbol: 'iTSLA',
+    symbol: 'TSLA',
     logo: 'tsla.webp',
     coinGeckoId: ''
   },
 
-  iGOOGL: {
+  GOOGL: {
     name: 'Alphabet',
     decimals: 6,
-    symbol: 'iGOOGL',
+    symbol: 'GOOGL',
     logo: 'googl.webp',
     coinGeckoId: ''
   },
@@ -511,42 +511,42 @@ export const untaggedSymbolMeta = {
     coinGeckoId: 'sign-global'
   },
 
-  iMETA: {
+  META: {
     name: 'Meta Platforms',
     decimals: 6,
-    symbol: 'iMETA',
+    symbol: 'META',
     logo: 'meta.webp',
     coinGeckoId: ''
   },
 
-  iAAPL: {
+  AAPL: {
     name: 'Apple Inc',
     decimals: 6,
-    symbol: 'iAAPL',
+    symbol: 'AAPL',
     logo: 'iaapl.webp',
     coinGeckoId: ''
   },
 
-  iMSFT: {
+  MSFT: {
     name: 'Microsoft Corp',
     decimals: 6,
-    symbol: 'iMSFT',
+    symbol: 'MSFT',
     logo: 'imsft.webp',
     coinGeckoId: ''
   },
 
-  iAMZN: {
+  AMZN: {
     name: 'Amazon Inc',
     decimals: 6,
-    symbol: 'iAMZN',
+    symbol: 'AMZN',
     logo: 'iamzn.webp',
     coinGeckoId: ''
   },
 
-  iNFLX: {
+  NFLX: {
     name: 'Netflix Corp',
     decimals: 6,
-    symbol: 'iNFLX',
+    symbol: 'NFLX',
     logo: 'inflx.webp',
     coinGeckoId: ''
   },
@@ -559,10 +559,10 @@ export const untaggedSymbolMeta = {
     coinGeckoId: ''
   },
 
-  iCRCL: {
+  CRCL: {
     name: 'Circle Internet Group Inc',
     decimals: 6,
-    symbol: 'iCRCL',
+    symbol: 'CRCL',
     logo: 'icrcl.webp',
     coinGeckoId: ''
   },
@@ -592,7 +592,7 @@ export const untaggedSymbolMeta = {
   },
   
   H100: {
-    name: 'Squaretower H100 Hourly',
+    name: 'NVIDIA H100',
     decimals: 6,
     symbol: 'H100',
     logo: 'h100.webp',


### PR DESCRIPTION
update iasset base tickers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized token symbols by removing a legacy prefix. Symbols now display as NVDA, HOOD, MSTR, COIN, TSLA, GOOGL, META, AAPL, MSFT, AMZN, NFLX, CRCL, MCD, and H100 across the app.
  * Updated the H100 asset’s display name to “NVIDIA H100”.
  * Improves consistency in listings, search, and portfolio views without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->