### PR TITLE
chore:update crude name for spacing

### DIFF
--- a/src/data/tokens/untaggedSymbolMeta.ts
+++ b/src/data/tokens/untaggedSymbolMeta.ts
@@ -600,7 +600,7 @@ export const untaggedSymbolMeta = {
   },
 
   WTIV5: {
-    name: 'WTI Crude Oil (22 Sep 2025 Expiry)',
+    name: 'WTI Crude Oil (22 Sep 25 Expiry)',
     decimals: 6,
     symbol: 'WTIV5',
     logo: 'wti.webp',


### PR DESCRIPTION
update crude name for spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed name for the WTI Crude Oil futures token to “WTI Crude Oil (22 Sep 25 Expiry)”, ensuring consistent labeling across asset lists, search, and trading screens.
* **Style**
  * Standardized the date format in the token name to a shorter year style, improving readability and alignment with other instrument names without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->