### PR TITLE
chore: add nept/usdt sgt

### DIFF
--- a/json/helix/trading/gridMarkets/spot/mainnet.json
+++ b/json/helix/trading/gridMarkets/spot/mainnet.json
@@ -182,5 +182,9 @@
   {
     "contractAddress": "inj1dapczy0ucxrm0h5xtwr8g8yghrq58hwqe5mx25",
     "slug": "arst-usdt"
+  },
+  {
+    "contractAddress": "inj1k2cs7mu4sm6qrqmex67ep6c7wzmp6m9qs94qng",
+    "slug": "nept-usdt"
   }
 ]


### PR DESCRIPTION
add nept/usdt sgt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the NEPT/USDT market in Grid Markets (Spot, Mainnet). You can now select NEPT/USDT when creating or managing grid strategies.
- Chores
  - Updated market listings to include the new pair, ensuring it appears in relevant selectors and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->