### PR TITLE
feat: add trading bots

### DIFF
--- a/json/helix/trading/gridMarkets/derivative/mainnet.json
+++ b/json/helix/trading/gridMarkets/derivative/mainnet.json
@@ -66,5 +66,53 @@
   {
     "slug": "buidl-usdt-perp",
     "contractAddress": "inj1hth3zy65689s3gtydhwr9a295syreyzj286x2y"
+  },
+  {
+    "slug": "wif-usdt-perp",
+    "contractAddress": "inj1mqydvjg6kvxx70neymz9y3kvh8kmu3mumamjmx"
+  },
+  {
+    "slug": "aapl-usdt-perp",
+    "contractAddress": "inj1pj2qnfyqnekw55e2keftc8963nynkemdja5am0"
+  },
+  {
+    "slug": "w-usdt-perp",
+    "contractAddress": "inj1x0pqcn7nwf8nrl5779wa8eug82eu5qx075t8h7"
+  },
+  {
+    "slug": "aave-usdt-perp",
+    "contractAddress": "inj13eulqq9pgyazcfap4eqh3shnpmmwvdusnqh0vs"
+  },
+  {
+    "slug": "msft-usdt-perp",
+    "contractAddress": "inj10ftjexstm33hj5e9jgezgcxx387mxn4p8jnfdj"
+  },
+  {
+    "slug": "ton-usdt-perp",
+    "contractAddress": "inj1yrj3ckuun5wwl9ps2x8m6ydfnvgujt3atzurj6"
+  },
+  {
+    "slug": "nvda-usdt-perp",
+    "contractAddress": "inj1fztxspkpmamc2tmmjvk6j3yszdtgp7uj0d6ey0"
+  },
+  {
+    "slug": "stx-usdt-perp",
+    "contractAddress": "inj10sjnxnr23cjuecqwwh7nnzrfdp524ns62ttm05"
+  },
+  {
+    "slug": "coin-usdt-perp",
+    "contractAddress": "inj13jq55e9v8p74zf7curezaxur8vdt7eezus8wzw"
+  },
+  {
+    "slug": "googl-usdt-perp",
+    "contractAddress": "inj1c7mptvewxf4vnvt89f0wh2t5wv66dcz3mghu23"
+  },
+  {
+    "slug": "nflx-usdt-perp",
+    "contractAddress": "inj13aat9hahx0slchulfv9duvw46h0qtns39t9uqp"
+  },
+  {
+    "slug": "apt-usdt-perp",
+    "contractAddress": "inj1jwg3lhc6ecw0c8lmwcam6c69lkrjqxmsvhgggz"
   }
 ]

--- a/json/helix/trading/gridMarkets/spot/mainnet.json
+++ b/json/helix/trading/gridMarkets/spot/mainnet.json
@@ -182,5 +182,9 @@
   {
     "contractAddress": "inj1dapczy0ucxrm0h5xtwr8g8yghrq58hwqe5mx25",
     "slug": "arst-usdt"
+  },
+  {
+    "contractAddress": "inj17emc2nvarpqzu5t34fr32jzfceynaxlj93v2va",
+    "slug": "nept-usdt"
   }
 ]

--- a/src/data/grid/derivative.ts
+++ b/src/data/grid/derivative.ts
@@ -66,6 +66,54 @@ export const mainnetGridMarkets = [
   {
     slug: 'buidl-usdt-perp',
     contractAddress: 'inj1hth3zy65689s3gtydhwr9a295syreyzj286x2y'
+  },
+  {
+    slug: 'wif-usdt-perp',
+    contractAddress: 'inj1mqydvjg6kvxx70neymz9y3kvh8kmu3mumamjmx'
+  },
+  {
+    slug: 'aapl-usdt-perp',
+    contractAddress: 'inj1pj2qnfyqnekw55e2keftc8963nynkemdja5am0'
+  },
+  {
+    slug: 'w-usdt-perp',
+    contractAddress: 'inj1x0pqcn7nwf8nrl5779wa8eug82eu5qx075t8h7'
+  },
+  {
+    slug: 'aave-usdt-perp',
+    contractAddress: 'inj13eulqq9pgyazcfap4eqh3shnpmmwvdusnqh0vs'
+  },
+  {
+    slug: 'msft-usdt-perp',
+    contractAddress: 'inj10ftjexstm33hj5e9jgezgcxx387mxn4p8jnfdj'
+  },
+  {
+    slug: 'ton-usdt-perp',
+    contractAddress: 'inj1yrj3ckuun5wwl9ps2x8m6ydfnvgujt3atzurj6'
+  },
+  {
+    slug: 'nvda-usdt-perp',
+    contractAddress: 'inj1fztxspkpmamc2tmmjvk6j3yszdtgp7uj0d6ey0'
+  },
+  {
+    slug: 'stx-usdt-perp',
+    contractAddress: 'inj10sjnxnr23cjuecqwwh7nnzrfdp524ns62ttm05'
+  },
+  {
+    slug: 'coin-usdt-perp',
+    contractAddress: 'inj13jq55e9v8p74zf7curezaxur8vdt7eezus8wzw'
+  },
+  {
+    slug: 'googl-usdt-perp',
+    contractAddress: 'inj1c7mptvewxf4vnvt89f0wh2t5wv66dcz3mghu23'
+  },
+  {
+    slug: 'nflx-usdt-perp',
+    contractAddress: 'inj13aat9hahx0slchulfv9duvw46h0qtns39t9uqp'
+  },
+  {
+    slug: 'apt-usdt-perp',
+    contractAddress: 'inj1jwg3lhc6ecw0c8lmwcam6c69lkrjqxmsvhgggz'
   }
 ]
 export const stagingGridMarkets = []

--- a/src/data/grid/spot.ts
+++ b/src/data/grid/spot.ts
@@ -182,11 +182,11 @@ export const mainnetGridMarkets = [
   {
     contractAddress: 'inj1dapczy0ucxrm0h5xtwr8g8yghrq58hwqe5mx25',
     slug: 'arst-usdt'
+  },
+  {
+    contractAddress: 'inj17emc2nvarpqzu5t34fr32jzfceynaxlj93v2va',
+    slug: 'nept-usdt'
   }
-  // {
-  //   contractAddress: 'inj1k2cs7mu4sm6qrqmex67ep6c7wzmp6m9qs94qng',
-  //   slug: 'nept-usdt'
-  // }
 ]
 
 export const stagingGridMarkets = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 12 new USDT perpetual markets to mainnet grid trading: WIF, AAPL, W, AAVE, MSFT, TON, NVDA, STX, COIN, GOOGL, NFLX, APT. These pairs are now selectable for strategy creation and monitoring.
  * Introduced a new mainnet spot grid market: NEPT/USDT, available alongside existing spot pairs. Existing markets remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->