### PR TITLE
chore: add hpnj meta

### DIFF
--- a/src/data/tokens/denoms.ts
+++ b/src/data/tokens/denoms.ts
@@ -33,5 +33,6 @@ export const verifiedTokenFactoryDenoms = [
   'factory/inj1aegme2dcy3dvk0v22wxdgd9609shyy2pgyh2kk/arst',
   'factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1x997dy6ka7y8u0r56yk2k83llspy33yet9zcnq',
   'factory/inj1nw35hnkz5j74kyrfq9ejlh2u4f7y7gt7c3ckde/PUGGO',
-  'factory/inj1khttezjv9x6dpadysffpf7m00rch2ldhezz7s2/tix'
+  'factory/inj1khttezjv9x6dpadysffpf7m00rch2ldhezz7s2/tix',
+  'factory/inj1ng84mfnq4z4tuh0cd7a28x0hxw75vxcm70ls9q/HPNJ'
 ]

--- a/src/data/tokens/symbolMeta.ts
+++ b/src/data/tokens/symbolMeta.ts
@@ -2365,7 +2365,7 @@ export const symbolMeta: Record<string, TokenSymbolMeta> = {
   HPNJ: {
     decimals: 8,
     name: 'Hyper Ninja Token',
-    logo: 'HPNG.webp',
+    logo: 'HPNJ.webp',
     symbol: 'HPNJ',
     coinGeckoId: ''
   }


### PR DESCRIPTION
 add hpnj meta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Hyper Ninja Token (HPNJ) by verifying its token factory denom, enabling recognition across balances, transfers, and swaps.
* **Bug Fixes**
  * Corrected the HPNJ token logo so it displays the proper asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->