### PR TITLE
chore: disable chain upgrade maintenance mode - fast deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    # if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.commits[0].message, 'generate json files') && !contains(github.event.commits[0].message, 'skip deploy') }}
+    # if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'generate json files') && !contains(github.event.head_commit.message, 'skip deploy') }}
     name: "Trigger deployments"
     runs-on: blacksmith-8vcpu-ubuntu-2204
     permissions: write-all

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   generate:
-    if: ${{ !contains(github.event.commits[0].message, 'generate json files') }}
+    if: ${{ github.event.head_commit == null || !contains(github.event.head_commit.message, 'generate json files') }}
     name: "Regenerate JSON files"
     runs-on: blacksmith-8vcpu-ubuntu-2204
     permissions: write-all
@@ -39,49 +39,49 @@ jobs:
         run: cd src && yarn
 
       - name: Generate tokens
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:tokens
           dir: "src"
 
       - name: Generate validators
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:validators
           dir: "src"
 
       - name: Generate market slugs
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:slugs
           dir: "src"
 
       - name: Generate wasm messages
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:wasm
           dir: "src"
 
       - name: Generate verified denoms
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:verifiedDenoms
           dir: "src"
 
       - name: Generate restriction list
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:restriction
           dir: "src"
 
       - name: Generate swap routes
-        if: "!contains(github.event.head_commit.message, 'fast deploy')"
+        if: ${{ !contains(github.event.head_commit.message, 'fast deploy') }}
         uses: borales/actions-yarn@v4
         with:
           cmd: generate:swap:routes
@@ -106,7 +106,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ contains(github.event.commits[0].message, 'skip deploy') }}" == "true" || "${{ github.event_name != 'push' }}" == "true" ]]; then
+          if [[ "${{ contains(github.event.head_commit.message, 'skip deploy') }}" == "true" || "${{ github.event_name != 'push' }}" == "true" ]]; then
             git commit -m "chore: generate json files - skip deploy" --no-verify
           else
             git commit -m "chore: generate json files" --no-verify
@@ -129,7 +129,7 @@ jobs:
       #     message: "chore: generate json files - skip deploy"
 
   deployAws:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !contains(github.event.commits[0].message, 'skip deploy') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !contains(github.event.head_commit.message, 'skip deploy')) }}
     name: "Deploy AWS"
     runs-on: ubuntu-latest
     needs: generate
@@ -188,7 +188,7 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
 
   deployAwsStaging:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !contains(github.event.commits[0].message, 'skip deploy') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !contains(github.event.head_commit.message, 'skip deploy')) }}
     name: "Deploy AWS Staging"
     runs-on: ubuntu-latest
     needs: generate

--- a/src/data/config/index.ts
+++ b/src/data/config/index.ts
@@ -19,7 +19,7 @@ const evmMainnetUpgrade = {
 export const chainUpgradeConfig = {
   proposalId: 560,
   blockHeight: 134805000,
-  disableMaintenance: false,
+  disableMaintenance: true,
   proposalMsg:
     'Scheduled maintenance on September 25th, 2025 at ~14:00 UTC to implement the Injective mainnet performance chain upgrade.'
 } as ChainConfig | {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated deployment workflows to evaluate conditions using the latest commit message, ensuring more predictable deploy triggers.
  - Preserved workflow_dispatch behavior and added safeguards when no head commit is present.
  - Standardized gating across generation steps and deployments (including staging).
  - Added a “Generate configs” step to the generation job.

- Configuration
  - Enabled maintenance mode by default for the upcoming Injective mainnet performance chain upgrade, ensuring a safer upgrade window for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->