### PR TITLE
feat: add hpnj trading bots

### DIFF
--- a/src/data/grid/spot.ts
+++ b/src/data/grid/spot.ts
@@ -186,7 +186,11 @@ export const mainnetGridMarkets = [
   {
     contractAddress: 'inj17emc2nvarpqzu5t34fr32jzfceynaxlj93v2va',
     slug: 'nept-usdt'
-  }
+  },
+  {
+    contractAddress: 'inj1k0tdjpfthwz7t6zlghrt27lwr5zpgqvrwn6khu',
+    slug: 'hpnj-inj'
+  },
 ]
 
 export const stagingGridMarkets = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new mainnet grid market for the HPNJ/INJ pair. Users can now select this market in the grid/spot interfaces for trading or strategy setup.
  * The new market appears in market selectors and related views with no changes required from users.
  * No other user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->