### PR TITLE
chore: unverify ausd spot markets

### DIFF
--- a/src/data/market/spot.ts
+++ b/src/data/market/spot.ts
@@ -41,9 +41,6 @@ export const mainnetMarketIds = [
   '0xc6b6d6627aeed8b9c29810163bed47d25c695d51a2aa8599fc5e39b2d88ef934', // shroom-inj
   '0x5a9c0f24d6bdd55373ec3d20bfb5c041674bab183dfff0548d1c8fedbf243ca1', // xion-usdt
   '0x6ff778593af355dc6b36d0c051d7f720dd284d35253f958a7b1d265e7df79693', // nept-inj
-  '0xae91b4f0c34ed3e7fbd9fbec1a9acbc74d53892de5e79e8da8f9537471dbd6b7', // ausd-usdt
-  '0x609376b88fd2e6e37ffc2ac9d6858633ab1d6c90ec6d100f9d205d38e531f8ac', // ausd-usdc
-  '0xee25f87facc4952d06b93d44ebb0e9eebf9ee1b39c6c7dcf6b14445b6bb6097e', // inj-ausd
   '0x6e46898e9a7ab9ff3c33791fa62ec108935837bab642833e1d17fa44d6ad038d' // nbz-usdt
 ]
 


### PR DESCRIPTION
unverify ausd spot markets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed three trading pairs from available mainnet markets: AUSD-USDT, AUSD-USDC, and INJ-AUSD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->