### PR TITLE
feat: update usdc grid markets

### DIFF
--- a/json/helix/trading/gridMarkets/spot/mainnet.json
+++ b/json/helix/trading/gridMarkets/spot/mainnet.json
@@ -92,8 +92,12 @@
     "contractAddress": "inj1ar6vmwfft83gzhqrl62r9l93tlclup8ss0suam"
   },
   {
-    "slug": "usdc-usdt",
+    "slug": "usdcnb-usdc",
     "contractAddress": "inj16ppjvumwvlur8e6r8le39j7wjrrh8dnjevx72h"
+  },
+  {
+    "contractAddress": "inj1ke59yqpz23dh4mheyh8fypnutnynhekdzrlkjh",
+    "slug": "usdc-usdt"
   },
   {
     "slug": "pyth-inj",

--- a/json/helix/trading/gridMarkets/spot/staging.json
+++ b/json/helix/trading/gridMarkets/spot/staging.json
@@ -92,8 +92,12 @@
     "contractAddress": "inj1ar6vmwfft83gzhqrl62r9l93tlclup8ss0suam"
   },
   {
-    "slug": "usdc-usdt",
+    "slug": "usdcnb-usdc",
     "contractAddress": "inj16ppjvumwvlur8e6r8le39j7wjrrh8dnjevx72h"
+  },
+  {
+    "contractAddress": "inj1ke59yqpz23dh4mheyh8fypnutnynhekdzrlkjh",
+    "slug": "usdc-usdt"
   },
   {
     "slug": "pyth-inj",

--- a/src/data/grid/spot.ts
+++ b/src/data/grid/spot.ts
@@ -92,8 +92,12 @@ export const mainnetGridMarkets = [
     contractAddress: 'inj1ar6vmwfft83gzhqrl62r9l93tlclup8ss0suam'
   },
   {
-    slug: 'usdc-usdt',
+    slug: 'usdcnb-usdc',
     contractAddress: 'inj16ppjvumwvlur8e6r8le39j7wjrrh8dnjevx72h'
+  },
+  {
+    contractAddress: 'inj1ke59yqpz23dh4mheyh8fypnutnynhekdzrlkjh',
+    slug: 'usdc-usdt'
   },
   {
     slug: 'pyth-inj',


### PR DESCRIPTION
Body

  ## What changed
  - renamed the existing `usdc-usdt` spot grid market entry to `usdcnb-usdc`
  - added the new `usdc-usdt` spot grid market entry with contract `inj1ke59yqpz23dh4mheyh8fypnutnynhekdzrlkjh`
  - regenerated the published spot grid market JSON outputs for `mainnet` and `staging`

  ## Why
  - the existing contract should remain available, but under the correct slug `usdcnb-usdc`
  - the new market should keep the `usdc-usdt` slug expected by the FE team

  ## Files changed
  - `src/data/grid/spot.ts`
  - `json/helix/trading/gridMarkets/spot/mainnet.json`
  - `json/helix/trading/gridMarkets/spot/staging.json`

  ## Validation
  - verified the source config change in `src/data/grid/spot.ts`
  - regenerated the grid market artifacts via `pnpm generate:slugs`
  - reviewed the final diff to confirm only the intended grid market mappings changed

  If you want, add this short note at the top:

  FE review requested for updated spot grid slug mapping: `usdcnb-usdc` + new `usdc-usdt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trading the new usdcnb-usdc market pair in spot grid markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->