### PR TITLE
feat: add 7 new spot grid markets with USDC pairs

### DIFF
--- a/json/helix/trading/gridMarkets/spot/mainnet.json
+++ b/json/helix/trading/gridMarkets/spot/mainnet.json
@@ -198,5 +198,33 @@
   {
     "contractAddress": "inj1cr35mf6u8lh5na5n20pcsat3ja58sx6pdl8vlj",
     "slug": "statom-atom"
+  },
+  {
+    "slug": "atom-usdc",
+    "contractAddress": "inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg"
+  },
+  {
+    "slug": "ausd-usdc",
+    "contractAddress": "inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e"
+  },
+  {
+    "slug": "hdro-usdc",
+    "contractAddress": "inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp"
+  },
+  {
+    "slug": "inj-usdc",
+    "contractAddress": "inj1a573wahqyjzrpzs2r9egfenmdfynnwgrje9c6f"
+  },
+  {
+    "slug": "sol-usdc",
+    "contractAddress": "inj1dx8kuevhq7m7g9a2e4es83ps62htr5g3y7azgr"
+  },
+  {
+    "slug": "weth-usdc",
+    "contractAddress": "inj1xzkeyvg3sgccz83qeq9hdj7ql4n2yewnpazcku"
+  },
+  {
+    "slug": "xion-usdc",
+    "contractAddress": "inj1jncgjgum339yl8rpnpdmd35lc82dfn8apcq7v0"
   }
 ]

--- a/json/helix/trading/gridMarkets/spot/mainnet.json
+++ b/json/helix/trading/gridMarkets/spot/mainnet.json
@@ -204,10 +204,6 @@
     "contractAddress": "inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg"
   },
   {
-    "slug": "ausd-usdc",
-    "contractAddress": "inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e"
-  },
-  {
     "slug": "hdro-usdc",
     "contractAddress": "inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp"
   },

--- a/json/helix/trading/gridMarkets/spot/staging.json
+++ b/json/helix/trading/gridMarkets/spot/staging.json
@@ -200,6 +200,34 @@
     "slug": "statom-atom"
   },
   {
+    "slug": "atom-usdc",
+    "contractAddress": "inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg"
+  },
+  {
+    "slug": "ausd-usdc",
+    "contractAddress": "inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e"
+  },
+  {
+    "slug": "hdro-usdc",
+    "contractAddress": "inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp"
+  },
+  {
+    "slug": "inj-usdc",
+    "contractAddress": "inj1a573wahqyjzrpzs2r9egfenmdfynnwgrje9c6f"
+  },
+  {
+    "slug": "sol-usdc",
+    "contractAddress": "inj1dx8kuevhq7m7g9a2e4es83ps62htr5g3y7azgr"
+  },
+  {
+    "slug": "weth-usdc",
+    "contractAddress": "inj1xzkeyvg3sgccz83qeq9hdj7ql4n2yewnpazcku"
+  },
+  {
+    "slug": "xion-usdc",
+    "contractAddress": "inj1jncgjgum339yl8rpnpdmd35lc82dfn8apcq7v0"
+  },
+  {
     "slug": "pyth-usdt",
     "contractAddress": "inj1t8g6vuj3hyu6r9lrdmgttvzm9wqxztr0uhfgls"
   }

--- a/json/helix/trading/gridMarkets/spot/staging.json
+++ b/json/helix/trading/gridMarkets/spot/staging.json
@@ -204,10 +204,6 @@
     "contractAddress": "inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg"
   },
   {
-    "slug": "ausd-usdc",
-    "contractAddress": "inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e"
-  },
-  {
     "slug": "hdro-usdc",
     "contractAddress": "inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp"
   },

--- a/src/data/grid/spot.ts
+++ b/src/data/grid/spot.ts
@@ -198,6 +198,34 @@ export const mainnetGridMarkets = [
   {
     contractAddress: 'inj1cr35mf6u8lh5na5n20pcsat3ja58sx6pdl8vlj',
     slug: 'statom-atom'
+  },
+  {
+    slug: 'atom-usdc',
+    contractAddress: 'inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg'
+  },
+  {
+    slug: 'ausd-usdc',
+    contractAddress: 'inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e'
+  },
+  {
+    slug: 'hdro-usdc',
+    contractAddress: 'inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp'
+  },
+  {
+    slug: 'inj-usdc',
+    contractAddress: 'inj1a573wahqyjzrpzs2r9egfenmdfynnwgrje9c6f'
+  },
+  {
+    slug: 'sol-usdc',
+    contractAddress: 'inj1dx8kuevhq7m7g9a2e4es83ps62htr5g3y7azgr'
+  },
+  {
+    slug: 'weth-usdc',
+    contractAddress: 'inj1xzkeyvg3sgccz83qeq9hdj7ql4n2yewnpazcku'
+  },
+  {
+    slug: 'xion-usdc',
+    contractAddress: 'inj1jncgjgum339yl8rpnpdmd35lc82dfn8apcq7v0'
   }
 ]
 

--- a/src/data/grid/spot.ts
+++ b/src/data/grid/spot.ts
@@ -204,10 +204,6 @@ export const mainnetGridMarkets = [
     contractAddress: 'inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg'
   },
   {
-    slug: 'ausd-usdc',
-    contractAddress: 'inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e'
-  },
-  {
     slug: 'hdro-usdc',
     contractAddress: 'inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp'
   },


### PR DESCRIPTION
## Summary

- Adds 7 new spot grid (SGT) markets to `mainnetGridMarkets` (and staging via spread):
  - `atom-usdc` — `inj1v3kl2ve7fsx8nx4nuvz7xd9vghxev6l220g8yg`
  - `ausd-usdc` — `inj1zmryuwcy9m80t535zvjydnw5rs6fkldceu2p8e`
  - `hdro-usdc` — `inj13k2n987huutmdq7hrp50mtkpej7aldw7dzjyxp`
  - `inj-usdc` — `inj1a573wahqyjzrpzs2r9egfenmdfynnwgrje9c6f`
  - `sol-usdc` — `inj1dx8kuevhq7m7g9a2e4es83ps62htr5g3y7azgr`
  - `weth-usdc` — `inj1xzkeyvg3sgccz83qeq9hdj7ql4n2yewnpazcku`
  - `xion-usdc` — `inj1jncgjgum339yl8rpnpdmd35lc82dfn8apcq7v0`
- `usdc-usdt` was already present with the same contract address and was skipped
- JSON files regenerated via `pnpm generate:slugs`

## Test plan

- [ ] Verify all 7 slugs resolve correctly in the spot market slug map
- [ ] Confirm contract addresses match on-chain deployments
- [ ] Spot-check `staging.json` includes the new entries (via `mainnetGridMarkets` spread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven new USDC market pairs: ATOM-USDC, aUSD-USDC, HDRO-USDC, INJ-USDC, SOL-USDC, WETH-USDC, and XION-USDC for grid trading on mainnet and staging environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/injective-lists/pull/403)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->