### PR TITLE
chore: disable chain upgrade banner - fast deploy

### DIFF
--- a/src/data/config/index.ts
+++ b/src/data/config/index.ts
@@ -19,7 +19,7 @@ const evmMainnetUpgrade = {
 export const chainUpgradeConfig = {
   proposalId: 690,
   blockHeight: 181295000,
-  disableMaintenance: false,
+  disableMaintenance: true,
   proposalMsg:
     'Scheduled maintenance on September 2nd, 2026 at ~17:30 UTC to implement the Injective Interoperability Mainnet Upgrade.'
 } as ChainConfig | {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance mode is now disabled for the Injective Interoperability Mainnet Upgrade configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->